### PR TITLE
Use java-11 to build Elasticsearch

### DIFF
--- a/cars/v1/vanilla/config.ini
+++ b/cars/v1/vanilla/config.ini
@@ -5,6 +5,6 @@ artifact_path_pattern = distribution/archives/oss-tar/build/distributions/*.tar.
 release_url = https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-{{VERSION}}.tar.gz
 docker_image=docker.elastic.co/elasticsearch/elasticsearch-oss
 # major version of the JDK that is used to build Elasticsearch
-build.jdk = 10
+build.jdk = 11
 # list of JDK major versions that are used to run Elasticsearch
-runtime.jdk = 10,9,8
+runtime.jdk = 11,10,9,8


### PR DESCRIPTION
Elasticsearch master (and 6.x) will require java-11 for
compilation once [1] has been merged.

Use java-11 to build Elasticsearch and add 11 to the list of eligible
JDK's to run Elasticsearch with.

[1] https://github.com/elastic/elasticsearch/pull/34103