### PR TITLE
Support zen2

### DIFF
--- a/cars/v1/vanilla/templates/config/elasticsearch.yml
+++ b/cars/v1/vanilla/templates/config/elasticsearch.yml
@@ -70,17 +70,13 @@ transport.tcp.port: {{transport_port}}
 #
 {%- if all_node_ips %}
 discovery.zen.ping.unicast.hosts: {{ all_node_ips }}
+# Prevent split brain by specifying the initial master nodes.
+cluster.initial_master_nodes: {{ all_node_ips }}
 {%- else %}
 #discovery.zen.ping.unicast.hosts: ["host1", "host2"]
+#cluster.initial_master_nodes: ["node-name1", "node-name2"]
 {%- endif %}
 #
-# Prevent the "split brain" by configuring the majority of nodes (total number of nodes / 2 + 1):
-#
-{%- if minimum_master_nodes %}
-discovery.zen.minimum_master_nodes: {{ minimum_master_nodes }}
-{%- else %}
-#discovery.zen.minimum_master_nodes: 3
-{%- endif %}
 #
 # For more information, see the documentation at:
 # <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery.html>


### PR DESCRIPTION
Starting with [1], `cluster.initial_master_nodes` is required. This
can point to a list of node names, but can also support a list of
<IP:PORT> or just <IP>  addresses.

Fix Elasticsearch setup by Rally on the `master` branch by supporting
the new cluster initial master nodes property.

Also remove `discovery.zen.minimum_master_nodes` which is not required
any more.

[1]
https://github.com/elastic/elasticsearch/commit/6e6e63d01da8fab85d3a69656416c39bfd8c9139