### PR TITLE
Remove ingest-geoip and ingest-user-agent from core plugins list

### DIFF
--- a/plugins/v1/core-plugins.txt
+++ b/plugins/v1/core-plugins.txt
@@ -20,8 +20,6 @@ discovery-ec2
 discovery-file
 discovery-gce
 ingest-attachment
-ingest-geoip
-ingest-user-agent
 lang-javascript
 lang-python
 mapper-attachments


### PR DESCRIPTION
ingest-geoip and ingest-user-agent are now packaged as modules in
Elasticsearch. Relates to elastic/elasticsearch#36956 and elastic/elasticsearch#36246