### PR TITLE
Remove deprecated default password property

### DIFF
--- a/cars/v1/x_pack/security/templates/config/elasticsearch.yml
+++ b/cars/v1/x_pack/security/templates/config/elasticsearch.yml
@@ -1,4 +1,3 @@
-xpack.security.authc.accept_default_password: false
 xpack.security.authc.token.enabled: false
 
 xpack.security.authc.realms:


### PR DESCRIPTION
With this commit we remove the deprecated property
`xpack.security.authc.accept_default_password`. There is no replacement
because default passwords are not allowed.