### PR TITLE
Always enable x-pack modules explicitly

### DIFF
--- a/cars/v1/default_distro/templates/config/elasticsearch.yml
+++ b/cars/v1/default_distro/templates/config/elasticsearch.yml
@@ -1,14 +1,6 @@
 xpack.license.self_generated.type: {{license_type|default('trial')}}
 
-{%- if xpack_ml_enabled is defined %}
-xpack.ml.enabled: {{xpack_ml_enabled}}
-{%- endif %}
-{%- if xpack_monitoring_enabled is defined %}
-xpack.monitoring.enabled: {{xpack_monitoring_enabled}}
-{%- endif %}
-{%- if xpack_security_enabled is defined %}
-xpack.security.enabled: {{xpack_security_enabled}}
-{%- endif %}
-{%- if xpack_watcher_enabled is defined %}
-xpack.watcher.enabled: {{xpack_watcher_enabled}}
-{%- endif %}
+xpack.ml.enabled: {{xpack_ml_enabled|default('false')}}
+xpack.monitoring.enabled: {{xpack_monitoring_enabled|default('false')}}
+xpack.security.enabled: {{xpack_security_enabled|default('false')}}
+xpack.watcher.enabled: {{xpack_watcher_enabled|default('false')}}


### PR DESCRIPTION
With this commit we always disable or enable x-pack modules explicitly
even when they are not available due to license. We have changed this
originally in #6 due to the basic license but this complicates how we
disable those modules in our nightly and release benchmarks and the old
way of specifying this works as well.