### PR TITLE
Don't parse log4j2.properties using jinja2

### DIFF
--- a/cars/v1/x_pack/security/templates/config/log4j2.properties
+++ b/cars/v1/x_pack/security/templates/config/log4j2.properties
@@ -1,3 +1,5 @@
+{# Don't parse this file using jinja2 #}
+{% raw %}
 appender.audit_rolling.type = RollingFile
 appender.audit_rolling.name = audit_rolling
 appender.audit_rolling.fileName = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_audit.json
@@ -81,3 +83,4 @@ logger.samlxml_decrypt.name = org.opensaml.xmlsec.encryption.support.Decrypter
 logger.samlxml_decrypt.level = fatal
 logger.saml2_decrypt.name = org.opensaml.saml.saml2.encryption.Decrypter
 logger.saml2_decrypt.level = fatal
+{% endraw %}


### PR DESCRIPTION
Fix `Encountered unknown tag 'map'` errors introduced in #15 because j2
tries to parse this file.