### PR TITLE
Update Djava.io.tmpdir parameter in jvm.options to add quotes

### DIFF
--- a/cars/v1/vanilla/templates/config/jvm.options
+++ b/cars/v1/vanilla/templates/config/jvm.options
@@ -69,7 +69,7 @@
 -Dlog4j.shutdownHookEnabled=false
 -Dlog4j2.disable.jmx=true
 
--Djava.io.tmpdir=${ES_TMPDIR}
+-Djava.io.tmpdir="${ES_TMPDIR}"
 
 ## heap dumps
 


### PR DESCRIPTION
After elasticsearch change, ${ES_TMPDIR} needs quotes around it.

Relates https://github.com/elastic/elasticsearch/pull/39959/