### PR TITLE
Revert 9d01d65867409c2c28620b842546b32fc8345e0b

### DIFF
--- a/cars/v1/vanilla/templates/config/jvm.options
+++ b/cars/v1/vanilla/templates/config/jvm.options
@@ -69,7 +69,7 @@
 -Dlog4j.shutdownHookEnabled=false
 -Dlog4j2.disable.jmx=true
 
--Djava.io.tmpdir="${ES_TMPDIR}"
+-Djava.io.tmpdir=${ES_TMPDIR}
 
 ## heap dumps
 


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/40312 removed the need
for quotes around ES_TMPDIR (which is the previous behavior), so remove
the double quotes here too.