### PR TITLE
Bump minimum Java version to Java 11

### DIFF
--- a/cars/v1/vanilla/config.ini
+++ b/cars/v1/vanilla/config.ini
@@ -7,4 +7,4 @@ docker_image=docker.elastic.co/elasticsearch/elasticsearch-oss
 # major version of the JDK that is used to build Elasticsearch
 build.jdk = 12
 # list of JDK major versions that are used to run Elasticsearch
-runtime.jdk = 12,11,10,9,8
+runtime.jdk = 12,11


### PR DESCRIPTION
Elasticsearch master bumps the minimum Java version to Java 11. With
this commit we follow suit.

Relates elastic/elasticsearch#40754