### PR TITLE
Allow to specify discovery type

### DIFF
--- a/cars/v1/vanilla/templates/config/elasticsearch.yml
+++ b/cars/v1/vanilla/templates/config/elasticsearch.yml
@@ -76,6 +76,9 @@ cluster.initial_master_nodes: {{ all_node_ips }}
 #discovery.seed_hosts: ["host1", "host2"]
 #cluster.initial_master_nodes: ["node-name1", "node-name2"]
 {%- endif %}
+{%- if discovery_type %}
+discovery.type: {{discovery_type}}
+{%- endif %}
 #
 #
 # For more information, see the documentation at:


### PR DESCRIPTION
With this commit we allow to pass the setting `discovery.type` as a
parameter which is handy for testing in Docker.