### PR TITLE
Remove node.max_local_storage_nodes

### DIFF
--- a/cars/v1/vanilla/templates/config/elasticsearch.yml
+++ b/cars/v1/vanilla/templates/config/elasticsearch.yml
@@ -98,7 +98,6 @@ discovery.type: {{discovery_type}}
 # Require explicit names when deleting indices:
 #
 #action.destructive_requires_name: true
-node.max_local_storage_nodes: {{node_count_per_host}}
 
 {# cluster settings provided from the track #}
 {%- for key, value in cluster_settings.items() %}


### PR DESCRIPTION
With this commit we remove the setting `node.max_local_storage_nodes`
which is dangerous and is also not used by Rally in a way that it would
be useful (the value is always `1` which is the default anyway).