### PR TITLE
Have G1-related settings match ES defaults

### DIFF
--- a/cars/v1/vanilla/templates/config/jvm.options
+++ b/cars/v1/vanilla/templates/config/jvm.options
@@ -42,7 +42,8 @@
 
 {%- if use_g1_gc is defined and use_g1_gc == 'true' %}
 -XX:+UseG1GC
--XX:InitiatingHeapOccupancyPercent=75
+-XX:InitiatingHeapOccupancyPercent=30
+-XX:G1ReservePercent=25
 {%- endif %}
 
 ## DNS cache policy


### PR DESCRIPTION
With this commit we align the G1-related settings to the new ES defaults
that will be introduced with elastic/elasticsearch#46169.

Relates elastic/elasticsearch#46169