### PR TITLE
Compile and run Elasticsearch with JDK 13

### DIFF
--- a/cars/v1/vanilla/config.ini
+++ b/cars/v1/vanilla/config.ini
@@ -5,6 +5,6 @@ artifact_path_pattern = distribution/archives/oss-linux-tar/build/distributions/
 release_url = https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-{{VERSION}}-linux-x86_64.tar.gz
 docker_image=docker.elastic.co/elasticsearch/elasticsearch-oss
 # major version of the JDK that is used to build Elasticsearch
-build.jdk = 12
+build.jdk = 13
 # list of JDK major versions that are used to run Elasticsearch
-runtime.jdk = 12,11
+runtime.jdk = 13,12,11


### PR DESCRIPTION
With this commit we set the required JDK for compiling Elasticsearch to
JDK 13 and also allow to run it with JDK 13.