### PR TITLE
Parameterize OS name + CPU arch in download URL.

### DIFF
--- a/cars/v1/default_distro/config.ini
+++ b/cars/v1/default_distro/config.ini
@@ -1,5 +1,5 @@
 [variables]
 build_command=./gradlew :distribution:archives:linux-tar:assemble
 artifact_path_pattern=distribution/archives/linux-tar/build/distributions/*.tar.gz
-release_url=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{VERSION}}-linux-x86_64.tar.gz
+release_url=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{VERSION}}-{{OSNAME}}-{{ARCH}}.tar.gz
 docker_image=docker.elastic.co/elasticsearch/elasticsearch


### PR DESCRIPTION
We should use the new template parameters to get the correct version of ES for our platform + arch.