### PR TITLE
Remove option to enable direct buffer pooling

### DIFF
--- a/cars/v1/vanilla/templates/config/jvm.options
+++ b/cars/v1/vanilla/templates/config/jvm.options
@@ -82,7 +82,6 @@
 -Dio.netty.noUnsafe=true
 -Dio.netty.noKeySetOptimization=true
 -Dio.netty.recycler.maxCapacityPerThread=0
--Dio.netty.allocator.numDirectArenas=0
 
 # log4j 2
 -Dlog4j.shutdownHookEnabled=false


### PR DESCRIPTION
With this commit we align Rally with Elasticsearch's defaults as
implemented in elastic/elasticsearch#47956.

Relates elastic/elasticsearch#47956