### PR TITLE
Use node name to specify initial master nodes

### DIFF
--- a/cars/v1/vanilla/templates/config/elasticsearch.yml
+++ b/cars/v1/vanilla/templates/config/elasticsearch.yml
@@ -71,7 +71,11 @@ transport.port: {{transport_port}}
 {%- if all_node_ips %}
 discovery.seed_hosts: {{ all_node_ips }}
 # Prevent split brain by specifying the initial master nodes.
+  {%- if all_node_names is defined %}
+cluster.initial_master_nodes: {{ all_node_names }}
+  {%- else %}
 cluster.initial_master_nodes: {{ all_node_ips }}
+  {%- endif %}
 {%- else %}
 #discovery.seed_hosts: ["host1", "host2"]
 #cluster.initial_master_nodes: ["node-name1", "node-name2"]


### PR DESCRIPTION
With this commit we use the Elasticsearch node name instead of its IP to
configure `cluster.initial_master_nodes`. This avoids any ambiguity in
case multiple nodes are configured per host. For backwards-compatibility
we fallback to previous behavior if the template variable
`all_node_names` is undefined.

Relates elastic/rally#804