### PR TITLE
Add flag to indicate if a bundled JDK is available

### DIFF
--- a/cars/v1/vanilla/config.ini
+++ b/cars/v1/vanilla/config.ini
@@ -8,3 +8,4 @@ docker_image=docker.elastic.co/elasticsearch/elasticsearch-oss
 build.jdk = 13
 # list of JDK major versions that are used to run Elasticsearch
 runtime.jdk = 13,12,11
+runtime.jdk.bundled = true


### PR DESCRIPTION
With this commit we add a new variable that indicates whether a
distribution contains a bundled JDK. This can be used in the future by
Rally for various decisions whether it requires a user-provided JDK on
the system.