### PR TITLE
Reference config properties specific to the system

### DIFF
--- a/cars/v1/default_distro/config.ini
+++ b/cars/v1/default_distro/config.ini
@@ -1,5 +1,15 @@
 [variables]
+# deprecated
 build_command=./gradlew :distribution:archives:linux-tar:assemble
+# new
+system.build_command = ./gradlew :distribution:archives:{{OSNAME}}-tar:assemble
+# deprecated
 artifact_path_pattern=distribution/archives/linux-tar/build/distributions/*.tar.gz
+# new
+system.artifact_path_pattern = distribution/archives/{{OSNAME}}-tar/build/distributions/*.tar.gz
+# deprecated
 release_url=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{VERSION}}-linux-x86_64.tar.gz
+# new
+jdk.bundled.release_url = https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{VERSION}}-{{OSNAME}}-{{ARCH}}.tar.gz
+jdk.unbundled.release_url = https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{VERSION}}-no-jdk-{{OSNAME}}-{{ARCH}}.tar.gz
 docker_image=docker.elastic.co/elasticsearch/elasticsearch

--- a/cars/v1/vanilla/config.ini
+++ b/cars/v1/vanilla/config.ini
@@ -1,8 +1,19 @@
 [variables]
 clean_command = ./gradlew clean
+# deprecated
 build_command = ./gradlew :distribution:archives:oss-linux-tar:assemble
+# new
+system.build_command = ./gradlew :distribution:archives:oss-{{OSNAME}}-tar:assemble
+# deprecated
 artifact_path_pattern = distribution/archives/oss-linux-tar/build/distributions/*.tar.gz
+# new
+system.artifact_path_pattern = distribution/archives/oss-{{OSNAME}}-tar/build/distributions/*.tar.gz
+# deprecated
 release_url = https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-{{VERSION}}-linux-x86_64.tar.gz
+# new
+jdk.bundled.release_url = https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-{{VERSION}}-{{OSNAME}}-{{ARCH}}.tar.gz
+jdk.unbundled.release_url = https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-{{VERSION}}-no-jdk-{{OSNAME}}-{{ARCH}}.tar.gz
+
 docker_image=docker.elastic.co/elasticsearch/elasticsearch-oss
 # major version of the JDK that is used to build Elasticsearch
 build.jdk = 13


### PR DESCRIPTION
With this commit we introduce new configuration properties that allow
Rally to change behavior (e.g. which build command is executed) based on
template variables. This enables us to build and download
system-specific artifacts which is needed e.g. in order to use the
bundled JDK.