### PR TITLE
Repository s3 and gcs keystore

### DIFF
--- a/plugins/v1/repository_gcs/README.md
+++ b/plugins/v1/repository_gcs/README.md
@@ -1,0 +1,26 @@
+This directory contains the (optional) keystore configuration for the `repository-gcs` plugin.
+For more details on secure settings for the repository-gcs plugin please refer to the [repository-gcs-client](https://www.elastic.co/guide/en/elasticsearch/plugins/7.5/repository-gcs-client.html) documentation.
+
+### Parameters
+
+This configuration allows to set the following parameters with Rally using `--plugin-params` in combination with `--elasticsearch-plugins="repository-gcs"`:
+
+* `credentials_file`: A string specifying the full path to the service account json file.
+* `client_name`: A string specifying the clientname to associate the service account file under.
+
+Example:
+
+`--elasticsearch-plugins="repository-gcs" --plugin-params="client_name:internalgcsclient,credentials_file:/home/user/service_account.json"`
+
+The above settings can also be stored in a JSON file that can be specified as well with `--plugin-params`.
+
+Example:
+
+```json
+{
+  "client_name": "internalgcsclient",
+  "credentials_file": "/home/user/service_account.json"
+}
+```   
+
+Save it as `params.json` and provide it to Rally with `--elasticsearch-plugins="repository-gcs" --plugin-params="/path/to/params.json"`.

--- a/plugins/v1/repository_gcs/README.md
+++ b/plugins/v1/repository_gcs/README.md
@@ -5,12 +5,14 @@ For more details on secure settings for the repository-gcs plugin please refer t
 
 This configuration allows to set the following parameters with Rally using `--plugin-params` in combination with `--elasticsearch-plugins="repository-gcs"`:
 
-* `credentials_file`: A string specifying the full path to the service account json file.
-* `client_name`: A string specifying the clientname to associate the service account file under.
+* `gcs_credentials_file`: A string specifying the full path to the service account json file.
+* `gcs_client_name`: A string specifying the clientname to associate the service account file under.
 
 Example:
 
-`--elasticsearch-plugins="repository-gcs" --plugin-params="client_name:internalgcsclient,credentials_file:/home/user/service_account.json"`
+`--elasticsearch-plugins="repository-gcs" --plugin-params="gcs_client_name:internalgcsclient,gcs_credentials_file:'/home/user/service_account.json'"`
+
+**IMPORTANT**: when provided in the inline format, the path to the credentials file needs to be enclosed in quotes.
 
 The above settings can also be stored in a JSON file that can be specified as well with `--plugin-params`.
 
@@ -18,8 +20,8 @@ Example:
 
 ```json
 {
-  "client_name": "internalgcsclient",
-  "credentials_file": "/home/user/service_account.json"
+  "gcs_client_name": "internalgcsclient",
+  "gcs_credentials_file": "/home/user/service_account.json"
 }
 ```   
 

--- a/plugins/v1/repository_gcs/README.md
+++ b/plugins/v1/repository_gcs/README.md
@@ -5,8 +5,8 @@ For more details on secure settings for the repository-gcs plugin please refer t
 
 This configuration allows to set the following parameters with Rally using `--plugin-params` in combination with `--elasticsearch-plugins="repository-gcs"`:
 
-* `gcs_credentials_file`: A string specifying the full path to the service account json file.
-* `gcs_client_name`: A string specifying the clientname to associate the service account file under.
+* `gcs_credentials_file`: A string specifying the full path to the service account json file (mandatory).
+* `gcs_client_name`: A string specifying the clientname to associate the service account file under (mandatory).
 
 Example:
 

--- a/plugins/v1/repository_gcs/README.md
+++ b/plugins/v1/repository_gcs/README.md
@@ -1,5 +1,5 @@
 This directory contains the (optional) keystore configuration for the `repository-gcs` plugin.
-For more details on secure settings for the repository-gcs plugin please refer to the [repository-gcs-client](https://www.elastic.co/guide/en/elasticsearch/plugins/7.5/repository-gcs-client.html) documentation.
+For more details on secure settings for the repository-gcs plugin please refer to the [repository-gcs-client](https://www.elastic.co/guide/en/elasticsearch/plugins/current/repository-gcs-client.html) documentation.
 
 ### Parameters
 

--- a/plugins/v1/repository_gcs/plugin.py
+++ b/plugins/v1/repository_gcs/plugin.py
@@ -35,7 +35,7 @@ def resolve_keystore_config(install_root):
 def create_keystore(install_root, keystore_binary, env):
     logger = logging.getLogger(LOGGER_NAME)
 
-    keystore_create_command = "{keystore} -s create".format(keystore=keystore_binary)
+    keystore_create_command = "{keystore} --silent create".format(keystore=keystore_binary)
 
     return_code = process.run_subprocess_with_logging(
         keystore_create_command,
@@ -50,12 +50,10 @@ def create_keystore(install_root, keystore_binary, env):
 
 def configure_keystore(config_names, variables, **kwargs):
     logger = logging.getLogger(LOGGER_NAME)
-    keystore_params = ["client_name", "credentials_file"]
-    client_name = variables.get("client_name")
+    keystore_params = ["gcs_client_name", "gcs_credentials_file"]
+    client_name = variables.get(keystore_params[0])
     credentials_file = variables.get(keystore_params[1])
 
-    logger.warning("%s", variables)
-    logger.warning("FOO: %s %s",client_name, credentials_file)
     if not (credentials_file and client_name):
         logger.warning("Skipping keystore configuration for repository-gcs as plugin-params %s were not supplied", keystore_params)
         return False
@@ -64,13 +62,11 @@ def configure_keystore(config_names, variables, **kwargs):
     install_root = variables["install_root_path"]
     keystore_binary = resolve_binary(install_root, keystore_binary_filename)
     env = kwargs.get("env")
-    credentials_file = variables.get("credentials_file")
-    client_name = variables.get("client_name")
 
     if resolve_keystore_config(install_root):
         create_keystore(install_root, keystore_binary, env)
 
-    keystore_command = "{keystore} -s add-file gcs.client.{client_name}.credentials_file {credentials_file}".format(
+    keystore_command = "{keystore} --silent add-file gcs.client.{client_name}.credentials_file {credentials_file}".format(
         keystore=keystore_binary,
         client_name=client_name,
         credentials_file=credentials_file)
@@ -83,7 +79,7 @@ def configure_keystore(config_names, variables, **kwargs):
     if return_code != 0:
         logger.error("%s has exited with code [%d]", keystore_command, return_code)
         raise exceptions.SystemSetupError(
-            "Could not add GCS keystore credentials. Please see the log for details.")
+            "Could not add GCS keystore secure setting. Please see the log for details.")
 
     # Success
     return True

--- a/plugins/v1/repository_gcs/plugin.py
+++ b/plugins/v1/repository_gcs/plugin.py
@@ -1,0 +1,93 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import logging
+import os
+
+from esrally.utils import process
+from esrally import exceptions
+
+LOGGER_NAME = "rally.provisioner.repository_gcs"
+
+
+def resolve_binary(install_root, binary_name):
+    return os.path.join(install_root, "bin", binary_name)
+
+
+def resolve_keystore_config(install_root):
+    return os.path.join(install_root, "config", "elasticsearch.keystore")
+
+
+def create_keystore(install_root, keystore_binary, env):
+    logger = logging.getLogger(LOGGER_NAME)
+
+    keystore_create_command = "{keystore} -s create".format(keystore=keystore_binary)
+
+    return_code = process.run_subprocess_with_logging(
+        keystore_create_command,
+        env=env
+    )
+
+    if return_code != 0:
+        logger.error("%s has exited with code [%d]", keystore_create_command, return_code)
+        raise exceptions.SystemSetupError(
+            "Could not initialize a keystore. Please see the log for details.")
+
+
+def configure_keystore(config_names, variables, **kwargs):
+    logger = logging.getLogger(LOGGER_NAME)
+    keystore_params = ["client_name", "credentials_file"]
+    client_name = variables.get("client_name")
+    credentials_file = variables.get(keystore_params[1])
+
+    logger.warning("%s", variables)
+    logger.warning("FOO: %s %s",client_name, credentials_file)
+    if not (credentials_file and client_name):
+        logger.warning("Skipping keystore configuration for repository-gcs as plugin-params %s were not supplied", keystore_params)
+        return False
+
+    keystore_binary_filename = "elasticsearch-keystore"
+    install_root = variables["install_root_path"]
+    keystore_binary = resolve_binary(install_root, keystore_binary_filename)
+    env = kwargs.get("env")
+    credentials_file = variables.get("credentials_file")
+    client_name = variables.get("client_name")
+
+    if resolve_keystore_config(install_root):
+        create_keystore(install_root, keystore_binary, env)
+
+    keystore_command = "{keystore} -s add-file gcs.client.{client_name}.credentials_file {credentials_file}".format(
+        keystore=keystore_binary,
+        client_name=client_name,
+        credentials_file=credentials_file)
+
+    return_code = process.run_subprocess_with_logging(
+        keystore_command,
+        env=env
+    )
+
+    if return_code != 0:
+        logger.error("%s has exited with code [%d]", keystore_command, return_code)
+        raise exceptions.SystemSetupError(
+            "Could not add GCS keystore credentials. Please see the log for details.")
+
+    # Success
+    return True
+
+
+def register(registry):
+    registry.register("post_install", configure_keystore)

--- a/plugins/v1/repository_gcs/plugin.py
+++ b/plugins/v1/repository_gcs/plugin.py
@@ -63,7 +63,7 @@ def configure_keystore(config_names, variables, **kwargs):
     keystore_binary = resolve_binary(install_root, keystore_binary_filename)
     env = kwargs.get("env")
 
-    if resolve_keystore_config(install_root):
+    if not os.path.isfile(resolve_keystore_config(install_root)):
         create_keystore(install_root, keystore_binary, env)
 
     keystore_command = "{keystore} --silent add-file gcs.client.{client_name}.credentials_file {credentials_file}".format(

--- a/plugins/v1/repository_gcs/plugin.py
+++ b/plugins/v1/repository_gcs/plugin.py
@@ -21,7 +21,7 @@ import os
 from esrally.utils import process
 from esrally import exceptions
 
-LOGGER_NAME = "rally.provisioner.repository_gcs"
+LOGGER_NAME = "esrally.provisioner.repository_gcs"
 
 
 def resolve_binary(install_root, binary_name):

--- a/plugins/v1/repository_s3/README.md
+++ b/plugins/v1/repository_s3/README.md
@@ -1,0 +1,28 @@
+This directory contains the (optional) keystore configuration for the `repository-s3` plugin.
+For more details on secure settings for the repository-s3 plugin please refer to the [repository-s3-client](https://www.elastic.co/guide/en/elasticsearch/plugins/7.5/repository-s3-client.html) documentation.
+
+### Parameters
+
+This configuration allows to set the following parameters with Rally using `--plugin-params` in combination with `--elasticsearch-plugins="repository-s3"`:
+
+* `aws_access_key`: A string specifying the AWS access key (mandatory)
+* `aws_secret_key`: A string specifying the AWS secret key (mandatory)
+* `aws_session_token`: A string specifying the AWS session token (optional)
+
+Example:
+
+`--elasticsearch-plugins="repository-gcs" --plugin-params="aws_access_key:XXXXX,aws_aws_secret_key:YYYYY,aws_session_token:ZZZZZ"`
+
+The above settings can also be stored in a JSON file that can be specified as well with `--plugin-params`.
+
+Example:
+
+```json
+{
+  "aws_access_key": "XXXXX",
+  "aws_secret_key": "YYYYY",
+  "aws_session_token": "ZZZZZ"
+}
+```   
+
+Save it as `params.json` and provide it to Rally with `--elasticsearch-plugins="repository-s3" --plugin-params="/path/to/params.json"`.

--- a/plugins/v1/repository_s3/README.md
+++ b/plugins/v1/repository_s3/README.md
@@ -5,13 +5,13 @@ For more details on secure settings for the repository-s3 plugin please refer to
 
 This configuration allows to set the following parameters with Rally using `--plugin-params` in combination with `--elasticsearch-plugins="repository-s3"`:
 
-* `aws_access_key`: A string specifying the AWS access key (mandatory)
-* `aws_secret_key`: A string specifying the AWS secret key (mandatory)
-* `aws_session_token`: A string specifying the AWS session token (optional)
+* `s3_access_key`: A string specifying the AWS access key (mandatory)
+* `s3_secret_key`: A string specifying the AWS secret key (mandatory)
+* `s3_session_token`: A string specifying the AWS session token (optional)
 
 Example:
 
-`--elasticsearch-plugins="repository-s3" --plugin-params="aws_access_key:XXXXX,aws_aws_secret_key:YYYYY,aws_session_token:ZZZZZ"`
+`--elasticsearch-plugins="repository-s3" --plugin-params="s3_access_key:XXXXX,aws_s3_secret_key:YYYYY,s3_session_token:ZZZZZ"`
 
 The above settings can also be stored in a JSON file that can be specified as well with `--plugin-params`.
 
@@ -19,9 +19,9 @@ Example:
 
 ```json
 {
-  "aws_access_key": "XXXXX",
-  "aws_secret_key": "YYYYY",
-  "aws_session_token": "ZZZZZ"
+  "s3_access_key": "XXXXX",
+  "s3_secret_key": "YYYYY",
+  "s3_session_token": "ZZZZZ"
 }
 ```   
 

--- a/plugins/v1/repository_s3/README.md
+++ b/plugins/v1/repository_s3/README.md
@@ -1,5 +1,5 @@
 This directory contains the (optional) keystore configuration for the `repository-s3` plugin.
-For more details on secure settings for the repository-s3 plugin please refer to the [repository-s3-client](https://www.elastic.co/guide/en/elasticsearch/plugins/7.5/repository-s3-client.html) documentation.
+For more details on secure settings for the repository-s3 plugin please refer to the [repository-s3-client](https://www.elastic.co/guide/en/elasticsearch/plugins/current/repository-s3-client.html) documentation.
 
 ### Parameters
 

--- a/plugins/v1/repository_s3/README.md
+++ b/plugins/v1/repository_s3/README.md
@@ -5,9 +5,10 @@ For more details on secure settings for the repository-s3 plugin please refer to
 
 This configuration allows to set the following parameters with Rally using `--plugin-params` in combination with `--elasticsearch-plugins="repository-s3"`:
 
-* `s3_access_key`: A string specifying the AWS access key (mandatory)
-* `s3_secret_key`: A string specifying the AWS secret key (mandatory)
-* `s3_session_token`: A string specifying the AWS session token (optional)
+* `s3_access_key`: A string specifying the AWS access key (mandatory).
+* `s3_secret_key`: A string specifying the AWS secret key (mandatory).
+* `s3_session_token`: A string specifying the AWS session token (optional).
+* `s3_client_name`: A string specifying the clientname to associate the above credentials with.
 
 Example:
 

--- a/plugins/v1/repository_s3/README.md
+++ b/plugins/v1/repository_s3/README.md
@@ -8,7 +8,7 @@ This configuration allows to set the following parameters with Rally using `--pl
 * `s3_access_key`: A string specifying the AWS access key (mandatory).
 * `s3_secret_key`: A string specifying the AWS secret key (mandatory).
 * `s3_session_token`: A string specifying the AWS session token (optional).
-* `s3_client_name`: A string specifying the clientname to associate the above credentials with.
+* `s3_client_name`: A string specifying the clientname to associate the above credentials with (mandatory).
 
 Example:
 

--- a/plugins/v1/repository_s3/README.md
+++ b/plugins/v1/repository_s3/README.md
@@ -11,7 +11,7 @@ This configuration allows to set the following parameters with Rally using `--pl
 
 Example:
 
-`--elasticsearch-plugins="repository-gcs" --plugin-params="aws_access_key:XXXXX,aws_aws_secret_key:YYYYY,aws_session_token:ZZZZZ"`
+`--elasticsearch-plugins="repository-s3" --plugin-params="aws_access_key:XXXXX,aws_aws_secret_key:YYYYY,aws_session_token:ZZZZZ"`
 
 The above settings can also be stored in a JSON file that can be specified as well with `--plugin-params`.
 

--- a/plugins/v1/repository_s3/plugin.py
+++ b/plugins/v1/repository_s3/plugin.py
@@ -1,0 +1,113 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import logging
+import os
+import shlex
+import subprocess
+
+from esrally.utils import process
+from esrally import exceptions
+
+LOGGER_NAME = "rally.provisioner.repository_s3"
+
+
+def resolve_binary(install_root, binary_name):
+    return os.path.join(install_root, "bin", binary_name)
+
+
+def resolve_keystore_config(install_root):
+    return os.path.join(install_root, "config", "elasticsearch.keystore")
+
+
+def create_keystore(install_root, keystore_binary, env):
+    logger = logging.getLogger(LOGGER_NAME)
+
+    keystore_create_command = "{keystore} -s create".format(keystore=keystore_binary)
+
+    return_code = process.run_subprocess_with_logging(
+        keystore_create_command,
+        env=env
+    )
+
+    if return_code != 0:
+        logger.error("%s has exited with code [%d]", keystore_create_command, return_code)
+        raise exceptions.SystemSetupError(
+            "Could not initialize a keystore. Please see the log for details.")
+
+
+def add_property_to_keystore(keystore_binary, client_name, property_name, property_value, env):
+    logger = logging.getLogger(LOGGER_NAME)
+
+    p1 = subprocess.Popen(["echo", property_value], stdout=subprocess.PIPE)
+
+    keystore_command = "{keystore} --silent add --stdin s3.client.{client_name}.{key}".format(
+        keystore=keystore_binary,
+        client_name=client_name,
+        key=property_name,
+        value=property_value)
+
+    return_code = process.run_subprocess_with_logging(
+        keystore_command,
+        stdin=p1.stdout,
+        env=env
+    )
+
+    if return_code != 0:
+        logger.error("%s has exited with code [%d]", keystore_command, return_code)
+        raise exceptions.SystemSetupError(
+            "Could not add S3 keystore secure setting. Please see the log for details.")
+
+
+def configure_keystore(config_names, variables, **kwargs):
+    logger = logging.getLogger(LOGGER_NAME)
+    # aws_session_token is optional
+    keystore_params = ["aws_access_key", "aws_secret_key", "aws_session_token"]
+    client_name = variables.get("client_name")
+
+    # skip keystore configuration entirely if any of the mandatory params is missing
+    if not (client_name and variables.get(keystore_params[0]) and variables.get(keystore_params[1])):
+        logger.warning("Skipping keystore configuration for repository-s3 as mandatory plugin-params [%s,%s,%s] were not supplied",
+                       "client_name",
+                       keystore_params[0],
+                       keystore_params[1])
+        return False
+
+    keystore_binary_filename = "elasticsearch-keystore"
+    install_root = variables["install_root_path"]
+    keystore_binary = resolve_binary(install_root, keystore_binary_filename)
+    env = kwargs.get("env")
+
+    if resolve_keystore_config(install_root):
+        create_keystore(install_root, keystore_binary, env)
+
+    for property_name in keystore_params:
+        # the actual Elasticsearch secure settings for the s3 plugin don't contain the _aws prefix
+        es_property_name = property_name.replace("aws_", "")
+        property_value = variables.get(property_name)
+        # skip optional properties like session_token
+        if not property_value:
+            continue
+
+        add_property_to_keystore(keystore_binary, client_name, es_property_name, property_value, env)
+
+    # Success
+    return True
+
+
+def register(registry):
+    registry.register("post_install", configure_keystore)

--- a/plugins/v1/repository_s3/plugin.py
+++ b/plugins/v1/repository_s3/plugin.py
@@ -70,7 +70,7 @@ def add_property_to_keystore(keystore_binary, client_name, property_name, proper
     if return_code != 0:
         logger.error("%s has exited with code [%d]", keystore_command, return_code)
         raise exceptions.SystemSetupError(
-            "Could not add S3 keystore secure setting [%s]. Please see the log for details.".format(property_name))
+            "Could not add S3 keystore secure setting [{}]. Please see the log for details.".format(property_name))
 
 
 def configure_keystore(config_names, variables, **kwargs):

--- a/plugins/v1/repository_s3/plugin.py
+++ b/plugins/v1/repository_s3/plugin.py
@@ -92,7 +92,7 @@ def configure_keystore(config_names, variables, **kwargs):
     keystore_binary = resolve_binary(install_root, keystore_binary_filename)
     env = kwargs.get("env")
 
-    if resolve_keystore_config(install_root):
+    if not os.path.isfile(resolve_keystore_config(install_root)):
         create_keystore(install_root, keystore_binary, env)
 
     for property_name in keystore_params:

--- a/plugins/v1/repository_s3/plugin.py
+++ b/plugins/v1/repository_s3/plugin.py
@@ -75,8 +75,8 @@ def add_property_to_keystore(keystore_binary, client_name, property_name, proper
 
 def configure_keystore(config_names, variables, **kwargs):
     logger = logging.getLogger(LOGGER_NAME)
-    # aws_session_token is optional
-    keystore_params = ["aws_access_key", "aws_secret_key", "aws_session_token"]
+    # s3_session_token is optional
+    keystore_params = ["s3_access_key", "s3_secret_key", "s3_session_token"]
     client_name = variables.get("client_name")
 
     # skip keystore configuration entirely if any of the mandatory params is missing
@@ -96,8 +96,8 @@ def configure_keystore(config_names, variables, **kwargs):
         create_keystore(install_root, keystore_binary, env)
 
     for property_name in keystore_params:
-        # the actual Elasticsearch secure settings for the s3 plugin don't contain the _aws prefix
-        es_property_name = property_name.replace("aws_", "")
+        # the actual Elasticsearch secure settings for the s3 plugin don't contain the s3_ prefix
+        es_property_name = property_name.replace("s3_", "")
         property_value = variables.get(property_name)
         # skip optional properties like session_token
         if not property_value:

--- a/plugins/v1/repository_s3/plugin.py
+++ b/plugins/v1/repository_s3/plugin.py
@@ -23,7 +23,7 @@ import subprocess
 from esrally.utils import process
 from esrally import exceptions
 
-LOGGER_NAME = "rally.provisioner.repository_s3"
+LOGGER_NAME = "esrally.provisioner.repository_s3"
 
 
 def resolve_binary(install_root, binary_name):

--- a/plugins/v1/repository_s3/plugin.py
+++ b/plugins/v1/repository_s3/plugin.py
@@ -58,8 +58,7 @@ def add_property_to_keystore(keystore_binary, client_name, property_name, proper
     keystore_command = "{keystore} --silent add --stdin s3.client.{client_name}.{key}".format(
         keystore=keystore_binary,
         client_name=client_name,
-        key=property_name,
-        value=property_value)
+        key=property_name)
 
     return_code = process.run_subprocess_with_logging(
         keystore_command,
@@ -77,7 +76,7 @@ def configure_keystore(config_names, variables, **kwargs):
     logger = logging.getLogger(LOGGER_NAME)
     # s3_session_token is optional
     keystore_params = ["s3_access_key", "s3_secret_key", "s3_session_token"]
-    client_name = variables.get("client_name")
+    client_name = variables.get("s3_client_name")
 
     # skip keystore configuration entirely if any of the mandatory params is missing
     if not (client_name and variables.get(keystore_params[0]) and variables.get(keystore_params[1])):

--- a/plugins/v1/repository_s3/plugin.py
+++ b/plugins/v1/repository_s3/plugin.py
@@ -70,7 +70,7 @@ def add_property_to_keystore(keystore_binary, client_name, property_name, proper
     if return_code != 0:
         logger.error("%s has exited with code [%d]", keystore_command, return_code)
         raise exceptions.SystemSetupError(
-            "Could not add S3 keystore secure setting. Please see the log for details.")
+            "Could not add S3 keystore secure setting [%s]. Please see the log for details.".format(property_name))
 
 
 def configure_keystore(config_names, variables, **kwargs):


### PR DESCRIPTION
Provide possibility to configure secure settings for the repository-s3 and
repository-gcs plugins via `--plugin-params`.
