### PR TITLE
Configurable x-pack-security settings

### DIFF
--- a/cars/v1/x_pack/README.md
+++ b/cars/v1/x_pack/README.md
@@ -1,18 +1,29 @@
-This directory contains example configurations for x-pack:
+# This directory contains example configurations for x-pack:
 
 * `security`: Configures TLS for all HTTP and transport communication using self-signed certificates.
-* `monitoring-local`: Enables x-pack monitoring with export to the current cluster.
+* `monitoring`: Enables x-pack monitoring with export to the current cluster.
 
 The configurations have been implemented so that you can either only one of them or both together, i.e. all of the following combinations will work:
 
-* `--elasticsearch-plugins="x-pack:security"`
-* `--elasticsearch-plugins="x-pack:monitoring-local"`
-* `--elasticsearch-plugins="x-pack:security+monitoring-local"`
+* `--car-plugins="x-pack-security"`
+* `--car-plugins="x-pack-monitoring-local"`
+* `--car-plugins="x-pack-security,x-pack-monitoring-local"`
 
-The `security` configuration will enable basic authentication and TLS for the HTTP and the transport layer. It will also add a `rally` super-user with the password `rally-password`. As a consequence, you will need to add the following client options when benchmarking this configuration:
+## Configuring security user name, password, role
+
+The `x-pack-security` car will enable basic authentication and TLS for the HTTP and the transport layer.
+You can additionally specify the user name, password and role, via the `car-params` cli arg, using the following properties:
+
+| car-params | default |
+| --------- | ------- |
+| xpack_security_user_name | rally |
+| xpack_security_user_password | rally-password |
+| xpack_security_user_role | superuser |
+
+Example:
 
 ```
---client-options="use_ssl:true,verify_certs:false,basic_auth_user:'rally',basic_auth_password:'rally-password'"
+esrally --distribution-version=7.5.1 --car="defaults,trial-license,x-pack-security" --car-params="xpack_security_user_name:myuser" --client-options="use_ssl:true,verify_certs:false,basic_auth_user:'myuser',basic_auth_password:'rally-password'"
 ```
 
 If you are benchmarking a single node cluster, you'll also need to add `--cluster-health=yellow ` as precondition checks in Rally mandate that the cluster health has to be "green" by default but the x-pack related indices are created with a higher replica count. 
@@ -22,6 +33,6 @@ If you are benchmarking a single node cluster, you'll also need to add `--cluste
 The focus here is on providing a usable configuration for benchmarks. This configuration is **NOT** suitable for production use because:
 
 * All clusters configured by Rally will use the same (self-signed) root certificate that will basically never expire
-* Rally will add a "rally" user with super-user privileges with a hard-coded password.
+* If you don't specify the car-params `x-pack_security_user_password` and `xpack_security_user_role`, Rally will add a "rally" user with super-user privileges with a hard-coded password.
 
 Both of these measures mean that the cluster is not any more secure than without using x-pack. But once again: The idea is to be able to measure the performance characteristics not to secure the cluster that is benchmarked.

--- a/cars/v1/x_pack/base/config.py
+++ b/cars/v1/x_pack/base/config.py
@@ -81,21 +81,38 @@ def add_rally_user(config_names, variables, **kwargs):
         return False
     logger = logging.getLogger(LOGGER_NAME)
     users_binary = "elasticsearch-users"
+    user_name = variables.get("xpack_security_user_name", "rally")
+    user_password = variables.get("xpack_security_user_password", "rally-password")
+    user_role = variables.get("xpack_security_user_role", "superuser")
     install_root = variables["install_root_path"]
-    logger.info("Adding user 'rally'.")
+    logger.info("Adding user '%s'.",user_name)
     users = resolve_binary(install_root, users_binary)
 
-    return_code = process.run_subprocess_with_logging('{users} useradd rally -p "rally-password"'.format(users=users),
-                                                      env=kwargs.get("env"))
+    return_code = process.run_subprocess_with_logging(
+        '{users} useradd {user_name} -p "{user_password}"'.format(
+            users=users,
+            user_name=user_name,
+            user_password=user_password
+        ),
+        env=kwargs.get("env"))
     if return_code != 0:
         logger.error("%s has exited with code [%d]", users_binary, return_code)
-        raise exceptions.SystemSetupError("Could not add user 'rally'. Please see the log for details.")
+        raise exceptions.SystemSetupError("Could not add user '{}'. Please see the log for details.".format(user_name))
 
-    return_code = process.run_subprocess_with_logging('{users} roles rally -a superuser'.format(users=users),
-                                                      env=kwargs.get("env"))
+    return_code = process.run_subprocess_with_logging(
+        '{users} roles {user_name} -a {user_role}'.format(
+            users=users,
+            user_name=user_name,
+            user_role=user_role
+        ),
+        env=kwargs.get("env"))
     if return_code != 0:
         logger.error("%s has exited with code [%d]", users_binary, return_code)
-        raise exceptions.SystemSetupError("Could not add role 'superuser' for user 'rally'. Please see the log for details.")
+        raise exceptions.SystemSetupError(
+            "Could not add role '{user_role}' for user '{user_name}'. Please see the log for details.".format(
+                user_role=user_role,
+                user_name=user_name
+            ))
 
     return True
 


### PR DESCRIPTION
This commit add support for configuring the user name, password and
role for the Elasticsearch (file realm) user generated by Rally when
using the x-pack-security car.

Also adjust docs now that x-pack-security is a car and not a plugin.