### PR TITLE
Configurable x-pack-security settings (#40)

### DIFF
--- a/cars/v1/x_pack/README.md
+++ b/cars/v1/x_pack/README.md
@@ -1,27 +1,68 @@
 This directory contains example configurations for x-pack:
 
-* `security`: Configures TLS for all HTTP and transport communication using self-signed certificates.
-* `monitoring-local`: Enables x-pack monitoring with export to the current cluster.
+* `x-pack-security`: Configures TLS for all HTTP and transport communication using self-signed certificates.
+* `x-pack-monitoring`: Enables x-pack monitoring.
+* `x-pack-ml`: Enables x-pack Machine Learning.
 
 The configurations have been implemented so that you can either only one of them or both together, i.e. all of the following combinations will work:
 
-* `--elasticsearch-plugins="x-pack:security"`
-* `--elasticsearch-plugins="x-pack:monitoring-local"`
-* `--elasticsearch-plugins="x-pack:security+monitoring-local"`
+* `--car="defaults,x-pack-security"`
+* `--car="defaults,x-pack-monitoring"`
+* `--car="defaults,x-pack-security,x-pack-monitoring-local"`
 
-The `security` configuration will enable basic authentication and TLS for the HTTP and the transport layer. It will also add a `rally` super-user with the password `rally-password`. As a consequence, you will need to add the following client options when benchmarking this configuration:
+## Parameters
+
+### x-pack-security
+
+The `x-pack-security` car will enable basic authentication and TLS for the HTTP and the transport layer.
+You can additionally specify the user name, password and role, via the `car-params` cli arg, using the following properties:
+
+| car-params | default |
+| --------- | ------- |
+| xpack_security_user_name | rally |
+| xpack_security_user_password | rally-password |
+| xpack_security_user_role | superuser |
+
+Example:
 
 ```
---client-options="use_ssl:true,verify_certs:false,basic_auth_user:'rally',basic_auth_password:'rally-password'"
+esrally --distribution-version=7.5.1 --car="defaults,trial-license,x-pack-security" --car-params="xpack_security_user_name:myuser" --client-options="use_ssl:true,verify_certs:false,basic_auth_user:'myuser',basic_auth_password:'rally-password'"
 ```
 
 If you are benchmarking a single node cluster, you'll also need to add `--cluster-health=yellow ` as precondition checks in Rally mandate that the cluster health has to be "green" by default but the x-pack related indices are created with a higher replica count. 
+
+### x-pack-monitoring
+
+When using the `x-pack-monitoring` config base, you must specify a `local` or `http` (remote) exporter via the **mandatory** property `monitoring_type`.
+Note that there are two cars, `x-pack-monitoring-local` and `x-pack-monitoring-http` that configure the `monitoring_type` property for you.
+Please refer to [Elasticsearch Monitoring Settings](https://www.elastic.co/guide/en/elasticsearch/reference/current/monitoring-settings.html) for more details.
+
+When using `http` as `monitoring_type` you should also configure the following properties:
+
+| car-params | description |
+| --------- | ------------ |
+| monitoring_host | The host of the monitoring cluster |
+| monitoring_port | The port of the monitoring cluster |
+| monitoring_user | The user to use on the monitoring cluster |
+| monitoring_password | The password of the monitoring cluster user |
+
+### x-pack-ml
+
+The following optional properties may be specified, see [ML settings](https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-settings.html) for more details:
+
+| car-params |
+| ---------- |
+| ml_max_open_jobs |
+| ml_max_machine_memory_percent |
+| ml_max_model_memory_limit |
+| ml_node_concurrent_job_allocations |
+
 
 **Security Note**
 
 The focus here is on providing a usable configuration for benchmarks. This configuration is **NOT** suitable for production use because:
 
 * All clusters configured by Rally will use the same (self-signed) root certificate that will basically never expire
-* Rally will add a "rally" user with super-user privileges with a hard-coded password.
+* If you don't specify the car-params `x-pack_security_user_password` and `xpack_security_user_role`, Rally will add a "rally" user with super-user privileges with a hard-coded password.
 
 Both of these measures mean that the cluster is not any more secure than without using x-pack. But once again: The idea is to be able to measure the performance characteristics not to secure the cluster that is benchmarked.

--- a/cars/v1/x_pack/base/config.py
+++ b/cars/v1/x_pack/base/config.py
@@ -81,21 +81,40 @@ def install_certificates(config_names, variables, **kwargs):
 def add_rally_user(config_names, variables, **kwargs):
     if "x-pack-security" not in config_names:
         return False
+
+    users_binary = "users"
+    user_name = variables.get("xpack_security_user_name", "rally")
+    user_password = variables.get("xpack_security_user_password", "rally-password")
+    user_role = variables.get("xpack_security_user_role", "superuser")
     install_root = variables["install_root_path"]
-    logger.info("Adding Rally user.")
-    users = resolve_binary(install_root, "users")
+    logger.info("Adding user '%s'.", user_name)
+    users = resolve_binary(install_root, users_binary)
 
-    # ./bin/x-pack/users useradd rally -p pw-rally-benchmark
-    return_code = process.run_subprocess_with_logging('{users} useradd rally -p "rally-password"'.format(users=users))
+    return_code = process.run_subprocess_with_logging(
+        '{users} useradd {user_name} -p "{user_password}"'.format(
+            users=users,
+            user_name=user_name,
+            user_password=user_password
+        ),
+        env=kwargs.get("env"))
     if return_code != 0:
-        logger.error("users has exited with code [%d]" % return_code)
-        raise exceptions.SystemSetupError("Could not add x-pack user 'rally'. Please see the log for details.")
+        logger.error("%s has exited with code [%d]", users_binary, return_code)
+        raise exceptions.SystemSetupError("Could not add user '{}'. Please see the log for details.".format(user_name))
 
-    # ./bin/x-pack/users roles rally -a superuser
-    return_code = process.run_subprocess_with_logging('{users} roles rally -a superuser'.format(users=users))
+    return_code = process.run_subprocess_with_logging(
+        '{users} roles {user_name} -a {user_role}'.format(
+            users=users,
+            user_name=user_name,
+            user_role=user_role
+        ),
+        env=kwargs.get("env"))
     if return_code != 0:
-        logger.error("users has exited with code [%d]" % return_code)
-        raise exceptions.SystemSetupError("Could not add role 'superuser' for user 'rally'. Please see the log for details.")
+        logger.error("%s has exited with code [%d]", users_binary, return_code)
+        raise exceptions.SystemSetupError(
+            "Could not add role '{user_role}' for user '{user_name}'. Please see the log for details.".format(
+                user_role=user_role,
+                user_name=user_name
+            ))
 
     return True
 


### PR DESCRIPTION
This commit add support for configuring the user name, password and
role for the Elasticsearch (file realm) user generated by Rally when
using the x-pack-security car.

Also adjust docs now that x-pack-security is a car and not a plugin.

Backport of #40