### PR TITLE
Store JVM error logs along Elasticsearch logs

### DIFF
--- a/cars/v1/vanilla/templates/config/jvm.options
+++ b/cars/v1/vanilla/templates/config/jvm.options
@@ -104,7 +104,11 @@
 {%- endif %}
 
 # specify an alternative path for JVM fatal error logs
+{%- if log_path is defined %}
+-XX:ErrorFile={{log_path}}/hs_err_pid%p.log
+{%- else %}
 # ${error.file}
+{%- endif %}
 
 ## JDK 8 GC logging
 


### PR DESCRIPTION
With this commit we specify the `-XX:ErrorFile` JVM parameter in
`jvm.options` and have it point to the log directory. By default, the
JVM writes this file to directory in which `java` is invoked (which is
the Elasticsearch root directory). This change simplifies archiving logs
and other data without accidentally missing the JVM error log.