### PR TITLE
Enabled native realm for x-pack-security car

### DIFF
--- a/cars/v1/x_pack/security/templates/config/elasticsearch.yml
+++ b/cars/v1/x_pack/security/templates/config/elasticsearch.yml
@@ -3,6 +3,8 @@ xpack.security.authc.token.enabled: false
 xpack.security.authc.realms:
   file.file1:
     order: 0
+  native.native1:
+    order: 1
 
 xpack.security.http.ssl.enabled: true
 xpack.security.http.ssl.keystore.type: PKCS12


### PR DESCRIPTION
Add native realm with lower order than file realm. The change support tests for native realm without affecting the priority of file realm.