### PR TITLE
Remove system JVM options

### DIFF
--- a/cars/v1/vanilla/templates/config/jvm.options
+++ b/cars/v1/vanilla/templates/config/jvm.options
@@ -46,47 +46,6 @@
 -XX:G1ReservePercent=25
 {%- endif %}
 
-## DNS cache policy
-# cache ttl in seconds for positive DNS lookups noting that this overrides the
-# JDK security property networkaddress.cache.ttl; set to -1 to cache forever
--Des.networkaddress.cache.ttl=60
-# cache ttl in seconds for negative DNS lookups noting that this overrides the
-# JDK security property networkaddress.cache.negative ttl; set to -1 to cache
-# forever
--Des.networkaddress.cache.negative.ttl=10
-
-## optimizations
-
-# pre-touch memory pages used by the JVM during initialization
--XX:+AlwaysPreTouch
-
-## basic
-
-# explicitly set the stack size
--Xss1m
-
-# set to headless, just in case
--Djava.awt.headless=true
-
-# ensure UTF-8 encoding by default (e.g. filenames)
--Dfile.encoding=UTF-8
-
-# use our provided JNA always versus the system one
--Djna.nosys=true
-
-# turn off a JDK optimization that throws away stack traces for common
-# exceptions because stack traces are important for debugging
--XX:-OmitStackTraceInFastThrow
-
-# flags to configure Netty
--Dio.netty.noUnsafe=true
--Dio.netty.noKeySetOptimization=true
--Dio.netty.recycler.maxCapacityPerThread=0
-
-# log4j 2
--Dlog4j.shutdownHookEnabled=false
--Dlog4j2.disable.jmx=true
-
 -Djava.io.tmpdir=${ES_TMPDIR}
 
 ## heap dumps
@@ -109,23 +68,6 @@
 {%- else %}
 # ${error.file}
 {%- endif %}
-
-## JDK 8 GC logging
-
-#8:-XX:+PrintGCDetails
-#8:-XX:+PrintGCDateStamps
-#8:-XX:+PrintTenuringDistribution
-#8:-XX:+PrintGCApplicationStoppedTime
-#8:-Xloggc:${loggc}
-#8:-XX:+UseGCLogFileRotation
-#8:-XX:NumberOfGCLogFiles=32
-#8:-XX:GCLogFileSize=64m
-
-# JDK 9+ GC logging
-#9-:-Xlog:gc*,gc+age=trace,safepoint:file=${loggc}:utctime,pid,tags:filecount=32,filesize=64m
-# due to internationalization enhancements in JDK 9 Elasticsearch need to set the provider to COMPAT otherwise
-# time/date parsing will break in an incompatible way for some date patterns and locals
-9-:-Djava.locale.providers=COMPAT
 
 {%- if additional_java_settings is defined %}
 {%- for value in additional_java_settings %}

--- a/cars/v1/vanilla/templates/config/jvm.options
+++ b/cars/v1/vanilla/templates/config/jvm.options
@@ -46,6 +46,7 @@
 -XX:G1ReservePercent=25
 {%- endif %}
 
+## JVM temporary directory
 -Djava.io.tmpdir=${ES_TMPDIR}
 
 ## heap dumps


### PR DESCRIPTION
With this commit we remove all JVM options that are considered "system
JVM options" which are already hardcoded in Elasticsearch and set by
default.

Relates elastic/elasticsearch#48252