### PR TITLE
Compile and run Elasticsearch with JDK 14

### DIFF
--- a/cars/v1/vanilla/config.ini
+++ b/cars/v1/vanilla/config.ini
@@ -16,7 +16,7 @@ jdk.unbundled.release_url = https://artifacts.elastic.co/downloads/elasticsearch
 
 docker_image=docker.elastic.co/elasticsearch/elasticsearch-oss
 # major version of the JDK that is used to build Elasticsearch
-build.jdk = 13
+build.jdk = 14
 # list of JDK major versions that are used to run Elasticsearch
-runtime.jdk = 13,12,11
+runtime.jdk = 14,13,12,11
 runtime.jdk.bundled = true


### PR DESCRIPTION
With this commit we set the required JDK for compiling Elasticsearch to
JDK 14 and also allow to run it with JDK 14.