### PR TITLE
Align default GC choice with Elasticsearch (#46)

### DIFF
--- a/cars/v1/vanilla/templates/config/jvm.options
+++ b/cars/v1/vanilla/templates/config/jvm.options
@@ -33,8 +33,17 @@
 ################################################################
 
 ## GC configuration
-{# The implicit default is to use CMS GC #}
-{%- if use_cms_gc is not defined or use_cms_gc == 'true' %}
+{# The implicit default is to use the default GC (depending on the JDK version) #}
+{%- if use_cms_gc is not defined and use_g1_gc is not defined %}
+8-13:-XX:+UseConcMarkSweepGC
+8-13:-XX:CMSInitiatingOccupancyFraction=75
+8-13:-XX:+UseCMSInitiatingOccupancyOnly
+14-:-XX:+UseG1GC
+14-:-XX:G1ReservePercent=25
+14-:-XX:InitiatingHeapOccupancyPercent=30
+{%- endif %}
+
+{%- if use_cms_gc is defined and use_cms_gc == 'true' %}
 -XX:+UseConcMarkSweepGC
 -XX:CMSInitiatingOccupancyFraction=75
 -XX:+UseCMSInitiatingOccupancyOnly
@@ -42,7 +51,8 @@
 
 {%- if use_g1_gc is defined and use_g1_gc == 'true' %}
 -XX:+UseG1GC
--XX:InitiatingHeapOccupancyPercent=75
+-XX:G1ReservePercent=25
+-XX:InitiatingHeapOccupancyPercent=30
 {%- endif %}
 
 ## optimizations

--- a/cars/v1/vanilla/templates/config/jvm.options
+++ b/cars/v1/vanilla/templates/config/jvm.options
@@ -87,6 +87,10 @@
 # exceptions because stack traces are important for debugging
 -XX:-OmitStackTraceInFastThrow
 
+# enable helpful NullPointerExceptions (https://openjdk.java.net/jeps/358), if
+# they are supported
+14-:-XX:+ShowCodeDetailsInExceptionMessages
+
 # flags to configure Netty
 -Dio.netty.noUnsafe=true
 -Dio.netty.noKeySetOptimization=true

--- a/cars/v1/vanilla/templates/config/jvm.options
+++ b/cars/v1/vanilla/templates/config/jvm.options
@@ -55,6 +55,15 @@
 -XX:InitiatingHeapOccupancyPercent=30
 {%- endif %}
 
+## DNS cache policy
+# cache ttl in seconds for positive DNS lookups noting that this overrides the
+# JDK security property networkaddress.cache.ttl; set to -1 to cache forever
+-Des.networkaddress.cache.ttl=60
+# cache ttl in seconds for negative DNS lookups noting that this overrides the
+# JDK security property networkaddress.cache.negative ttl; set to -1 to cache
+# forever
+-Des.networkaddress.cache.negative.ttl=10
+
 ## optimizations
 
 # pre-touch memory pages used by the JVM during initialization


### PR DESCRIPTION
With this commit we align with Elasticsearch defaults when the garbage
collector is not explicitly specified (CMS for JDK 8-13 and G1 starting
with JDK 14) but still allow to override this choice. This ensures that
Rally will choose the correct GC algorithm when Elasticsearch will be
started with a bundled JDK 14.