### PR TITLE
Add Parallel GC mixin

### DIFF
--- a/cars/v1/parallelgc.ini
+++ b/cars/v1/parallelgc.ini
@@ -7,5 +7,5 @@ base=vanilla
 
 [variables]
 use_cms_gc=false
-use_parallel_gc=false
-use_g1_gc=true
+use_g1_gc=false
+use_parallel_gc=true

--- a/cars/v1/parallelgc.ini
+++ b/cars/v1/parallelgc.ini
@@ -1,5 +1,5 @@
 [meta]
-description=Enables the G1 garbage collector
+description=Enables the Parallel garbage collector
 type=mixin
 
 [config]

--- a/cars/v1/vanilla/templates/config/jvm.options
+++ b/cars/v1/vanilla/templates/config/jvm.options
@@ -34,7 +34,7 @@
 
 ## GC configuration
 {# The implicit default is to use the default GC (depending on the JDK version) #}
-{%- if use_cms_gc is not defined and use_g1_gc is not defined %}
+{%- if use_cms_gc is not defined and use_g1_gc is not defined and use_parallel_gc is not defined %}
 8-13:-XX:+UseConcMarkSweepGC
 8-13:-XX:CMSInitiatingOccupancyFraction=75
 8-13:-XX:+UseCMSInitiatingOccupancyOnly
@@ -53,6 +53,10 @@
 -XX:+UseG1GC
 -XX:G1ReservePercent=25
 -XX:InitiatingHeapOccupancyPercent=30
+{%- endif %}
+
+{%- if use_parallel_gc is defined and use_parallel_gc == 'true' %}
+-XX:+UseParallelGC
 {%- endif %}
 
 ## JVM temporary directory


### PR DESCRIPTION
Adding car mixin to be able to run with -XX:+UseParallelGC when `parallelgc` is specified.