### PR TITLE
Align default GC choice with Elasticsearch (#46)

### DIFF
--- a/cars/v1/vanilla/templates/config/jvm.options
+++ b/cars/v1/vanilla/templates/config/jvm.options
@@ -33,8 +33,17 @@
 ################################################################
 
 ## GC configuration
-{# The implicit default is to use CMS GC #}
-{%- if use_cms_gc is not defined or use_cms_gc == 'true' %}
+{# The implicit default is to use the default GC (depending on the JDK version) #}
+{%- if use_cms_gc is not defined and use_g1_gc is not defined %}
+8-13:-XX:+UseConcMarkSweepGC
+8-13:-XX:CMSInitiatingOccupancyFraction=75
+8-13:-XX:+UseCMSInitiatingOccupancyOnly
+14-:-XX:+UseG1GC
+14-:-XX:G1ReservePercent=25
+14-:-XX:InitiatingHeapOccupancyPercent=30
+{%- endif %}
+
+{%- if use_cms_gc is defined and use_cms_gc == 'true' %}
 -XX:+UseConcMarkSweepGC
 -XX:CMSInitiatingOccupancyFraction=75
 -XX:+UseCMSInitiatingOccupancyOnly
@@ -42,8 +51,8 @@
 
 {%- if use_g1_gc is defined and use_g1_gc == 'true' %}
 -XX:+UseG1GC
--XX:InitiatingHeapOccupancyPercent=30
 -XX:G1ReservePercent=25
+-XX:InitiatingHeapOccupancyPercent=30
 {%- endif %}
 
 ## DNS cache policy


### PR DESCRIPTION
With this commit we align with Elasticsearch defaults when the garbage
collector is not explicitly specified (CMS for JDK 8-13 and G1 starting
with JDK 14) but still allow to override this choice. This ensures that
Rally will choose the correct GC algorithm when Elasticsearch will be
started with a bundled JDK 14.

Backport for https://github.com/elastic/rally-teams/pull/46