### PR TITLE
Expose indexing pressure as car parameter

### DIFF
--- a/cars/v1/vanilla/README.md
+++ b/cars/v1/vanilla/README.md
@@ -5,6 +5,7 @@ This directory contains the Elasticsearch base configuration.
 This configuration allows to set the following parameters with Rally 0.10.0 using `--car-params`:
 
 * `data_paths` (default: "data" (relative to the Elasticsearch root directory)): A string specifying the Elasticsearch data path.
+* `indexing_pressure_memory_limit` (default: not set): A percentage value defining the cluster setting [`indexing_pressure.memory.limit`](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-indexing-pressure.html).
 * `additional_cluster_settings` (default: empty): A dictionary of key-value pairs with additional settings in `elasticsearch.yml`.
 * `additional_java_settings` (default: empty): A list of additional settings in `jvm.options`. Each entry in the list will end up as one line in `jvm.options`.
 

--- a/cars/v1/vanilla/templates/config/elasticsearch.yml
+++ b/cars/v1/vanilla/templates/config/elasticsearch.yml
@@ -103,6 +103,10 @@ discovery.type: {{discovery_type}}
 #
 #action.destructive_requires_name: true
 
+{%- if indexing_pressure_memory_limit is defined %}
+indexing_pressure.memory.limit: {{indexing_pressure_memory_limit}}
+{%- endif %}
+
 {# cluster settings provided from the track #}
 {%- for key, value in cluster_settings.items() %}
 {{key}}: {{value | tojson}}


### PR DESCRIPTION
With this commit we expose the cluster setting
`indexing_pressure.memory.limit` as a car parameter. This allows us to
override this setting in all cases but leaves the decision to
rally-teams whether it is applicable for a specific release.