### PR TITLE
Allow wildcards for destructive actions

### DIFF
--- a/cars/v1/vanilla/templates/config/elasticsearch.yml
+++ b/cars/v1/vanilla/templates/config/elasticsearch.yml
@@ -99,9 +99,9 @@ discovery.type: {{discovery_type}}
 #
 # ---------------------------------- Various -----------------------------------
 #
-# Require explicit names when deleting indices:
+# Allow wildcard deletion of indices:
 #
-#action.destructive_requires_name: true
+action.destructive_requires_name: true
 
 {%- if indexing_pressure_memory_limit is defined %}
 indexing_pressure.memory.limit: {{indexing_pressure_memory_limit}}


### PR DESCRIPTION
With this commit we enforce prior behavior that wildcards are allowed
for destructrive actions as elastic/elasticearch#66908 changes the
default value to disable this behavior. This is a stopgap until Rally
can explicitly provide explicit names for destructive actions.

Relates elastic/elasticsearch#66908