### PR TITLE
Really allow wildcards for destructive actions

### DIFF
--- a/cars/v1/vanilla/templates/config/elasticsearch.yml
+++ b/cars/v1/vanilla/templates/config/elasticsearch.yml
@@ -101,7 +101,7 @@ discovery.type: {{discovery_type}}
 #
 # Allow wildcard deletion of indices:
 #
-action.destructive_requires_name: true
+action.destructive_requires_name: false
 
 {%- if indexing_pressure_memory_limit is defined %}
 indexing_pressure.memory.limit: {{indexing_pressure_memory_limit}}


### PR DESCRIPTION
With #58 we had explicitly set `action.destructive_requires_name` but
to allow wildcards this setting needs to be set to `false`. With this
commit we correct this mistake.

Relates #58