### PR TITLE
Update the versioning scheme docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,26 +12,27 @@ Versioning Scheme
 
 From time to time, settings change in Elasticsearch. As we want to be able to support multiple versions of Elasticsearch, we also need to version our team specifications. Therefore, this repository contains multiple branches. The following examples should give you an idea how the versioning scheme works:
 
-* master: compatible with the latest development version of Elasticsearch
-* 5.0.0-alpha2: compatible with the released version 5.0.0-alpha2.
-* 2: compatible with all Elasticsearch releases with the major release number 2 (e.g. 2.1, 2.2, 2.2.1)
-* 1.7: compatible with all Elasticsearch releases with the major release number 1 and minor release number 7 (e.g. 1.7.0, 1.7.1, 1.7.2)
+* `master`: compatible with the latest development version of Elasticsearch
+* `7.0.0-beta1`: compatible with the released version `7.0.0-beta1`.
+* `7.3`: compatible with all ES `7` releases equal or greater than `7.3` (e.g. `7.3.0`, `7.10.2`)
+* `6`: compatible with all Elasticsearch releases with the major release number 6 (e.g. `6.4.0`, `6.8.13`)
 
 As you can see, branches can match exact release numbers but Rally is also lenient in case settings did not change for a few releases. Rally will try to match in the following order:
 
-1. major.minor.patch-extension_label (e.g. 5.0.0-alpha5)
-2. major.minor.patch (e.g. 2.3.1)
-3. major.minor (e.g. 2.3)
-4. major (e.g. 2)
+1. Exact match major.minor.patch-extension_label (e.g. `7.0.0-beta1`)
+2. Exact match major.minor.patch (e.g. `7.10.2`, `6.7.0`)
+3. Exact match major.minor (e.g. `7.10`)
+4. Nearest prior minor branch (e.g. if available branches are `master`, `7`, `7.2` and `7.11` attempting to benchmarking ES `7.10.2` will choose `7.2`, whereas benchmarking ES `7.12.1` will choose the 7.11 branch) 
+5. Nearest major branch (e.g. if available branches are `master`, `5`, `6`,`7`, benchmarking ES `7.11` will choose the `7` branch)
 
-Apart from that, the master branch is always considered to be compatible with the Elasticsearch master branch.
+Apart from that, the `master` branch is always considered to be compatible with the Elasticsearch `master` branch.
 
-To specify the version to check against, add `--distribution-version` when running Rally. It it is not specified, Rally assumes that you want to benchmark against the Elasticsearch master version. 
+To specify the version to check against, add `--distribution-version` when running Rally. If it is not specified, Rally assumes that you want to benchmark against the Elasticsearch master version. 
 
-Example: If you want to benchmark Elasticsearch 5.0.0, run the following command:
+Example: If you want to benchmark Elasticsearch 7.10.2, run the following command:
 
 ```
-esrally --distribution-version=5.0.0
+esrally --distribution-version=7.10.2
 ```
 
 How to Contribute


### PR DESCRIPTION
This commit updates the versioning scheme docs to reflect the changes
brought in https://github.com/elastic/rally/pull/1165