### PR TITLE
Allow to specify the scheme of the monitoring URL

### DIFF
--- a/cars/v1/x_pack/README.md
+++ b/cars/v1/x_pack/README.md
@@ -39,12 +39,13 @@ Please refer to [Elasticsearch Monitoring Settings](https://www.elastic.co/guide
 
 When using `http` as `monitoring_type` you should also configure the following properties:
 
-| car-params | description |
-| --------- | ------------ |
-| monitoring_host | The host of the monitoring cluster |
-| monitoring_port | The port of the monitoring cluster |
-| monitoring_user | The user to use on the monitoring cluster |
-| monitoring_password | The password of the monitoring cluster user |
+| car-params | description | default |
+| --------- | ------------ | ------- |
+| monitoring_scheme | The scheme of the monitoring cluster | http |
+| monitoring_host | The host of the monitoring cluster | - |
+| monitoring_port | The port of the monitoring cluster | 9200 |
+| monitoring_user | The user to use on the monitoring cluster | - |
+| monitoring_password | The password of the monitoring cluster user | - |
 
 ### x-pack-ml
 

--- a/cars/v1/x_pack/monitoring/templates/config/elasticsearch.yml
+++ b/cars/v1/x_pack/monitoring/templates/config/elasticsearch.yml
@@ -4,6 +4,8 @@ xpack.monitoring.exporters.custom:
   type: {{monitoring_type}}
 {%- if monitoring_host is defined and monitoring_scheme is defined %}
   host: ["{{monitoring_scheme|default('http')}}://{{monitoring_host}}:{{monitoring_port|default('9200')}}"]
+{%- elif monitoring_host is defined %}
+  host: ["{{monitoring_host}}:{{monitoring_port|default('9200')}}"]
 {%- endif %}
 {%- if monitoring_user is defined %}
   auth.username: {{monitoring_user}}

--- a/cars/v1/x_pack/monitoring/templates/config/elasticsearch.yml
+++ b/cars/v1/x_pack/monitoring/templates/config/elasticsearch.yml
@@ -2,8 +2,8 @@ xpack.monitoring.collection.enabled: true
 
 xpack.monitoring.exporters.custom:
   type: {{monitoring_type}}
-{%- if monitoring_host is defined and monitoring_port is defined %}
-  host: ["{{monitoring_scheme|default('http')}}://{{monitoring_host}}:{{monitoring_port}}"]
+{%- if monitoring_host is defined %}
+  host: ["{{monitoring_scheme|default('http')}}://{{monitoring_host}}:{{monitoring_port|default('9200')}}"]
 {%- endif %}
 {%- if monitoring_user is defined %}
   auth.username: {{monitoring_user}}

--- a/cars/v1/x_pack/monitoring/templates/config/elasticsearch.yml
+++ b/cars/v1/x_pack/monitoring/templates/config/elasticsearch.yml
@@ -3,7 +3,7 @@ xpack.monitoring.collection.enabled: true
 xpack.monitoring.exporters.custom:
   type: {{monitoring_type}}
 {%- if monitoring_host is defined and monitoring_port is defined %}
-  host: ["{{monitoring_host}}:{{monitoring_port}}"]
+  host: ["{{monitoring_scheme|default('http')}}://{{monitoring_host}}:{{monitoring_port}}"]
 {%- endif %}
 {%- if monitoring_user is defined %}
   auth.username: {{monitoring_user}}

--- a/cars/v1/x_pack/monitoring/templates/config/elasticsearch.yml
+++ b/cars/v1/x_pack/monitoring/templates/config/elasticsearch.yml
@@ -2,7 +2,7 @@ xpack.monitoring.collection.enabled: true
 
 xpack.monitoring.exporters.custom:
   type: {{monitoring_type}}
-{%- if monitoring_host is defined %}
+{%- if monitoring_host is defined and monitoring_scheme is defined %}
   host: ["{{monitoring_scheme|default('http')}}://{{monitoring_host}}:{{monitoring_port|default('9200')}}"]
 {%- endif %}
 {%- if monitoring_user is defined %}


### PR DESCRIPTION
This commit allows one to send monitoring data to Elasticsearch clusters with HTTPS enabled.