### PR TITLE
Use string for path.data

### DIFF
--- a/cars/v1/vanilla/templates/config/elasticsearch.yml
+++ b/cars/v1/vanilla/templates/config/elasticsearch.yml
@@ -28,9 +28,9 @@ node.name: {{node_name}}
 #
 # ----------------------------------- Paths ------------------------------------
 #
-# Path to directory where to store the data (separate multiple locations by comma):
+# Path to directory where to store the data
 #
-path.data: {{data_paths}}
+path.data: {{data_paths[0]}}
 #
 # Path to log files:
 #


### PR DESCRIPTION
Hot fix to ensure path.data works correctly (and consequently index_size
gets reported properly in the metrics store).

Once we deal this in a better way in Rally, this will be reverted.

Relates https://github.com/elastic/rally/issues/1255