### PR TITLE
Run Elasticsearch with JDK 17

### DIFF
--- a/cars/v1/vanilla/config.ini
+++ b/cars/v1/vanilla/config.ini
@@ -18,5 +18,5 @@ docker_image=docker.elastic.co/elasticsearch/elasticsearch
 # major version of the JDK that is used to build Elasticsearch
 build.jdk = 16
 # list of JDK major versions that are used to run Elasticsearch
-runtime.jdk = 16,15,14,13,12,11
+runtime.jdk = 17,16,15,14,13,12,11
 runtime.jdk.bundled = true


### PR DESCRIPTION
With this commit we set the required JDK 17 for running Elasticsearch.