### PR TITLE
Bump minimum compiler version for ES 7.17 to Java 17

### DIFF
--- a/cars/v1/vanilla/config.ini
+++ b/cars/v1/vanilla/config.ini
@@ -18,5 +18,5 @@ docker_image=docker.elastic.co/elasticsearch/elasticsearch
 # major version of the JDK that is used to build Elasticsearch
 build.jdk = 17
 # list of JDK major versions that are used to run Elasticsearch
-runtime.jdk = 17,16,15,14,13,12,11
+runtime.jdk = 17,16,15,14,13,12,11,8
 runtime.jdk.bundled = true

--- a/cars/v1/vanilla/config.ini
+++ b/cars/v1/vanilla/config.ini
@@ -16,7 +16,7 @@ jdk.unbundled.release_url = https://artifacts.elastic.co/downloads/elasticsearch
 
 docker_image=docker.elastic.co/elasticsearch/elasticsearch
 # major version of the JDK that is used to build Elasticsearch
-build.jdk = 12
+build.jdk = 17
 # list of JDK major versions that are used to run Elasticsearch
-runtime.jdk = 12,11,8
+runtime.jdk = 17,16,15,14,13,12,11
 runtime.jdk.bundled = true


### PR DESCRIPTION
Relates https://github.com/elastic/elasticsearch/pull/85935