### PR TITLE
Run Elasticsearch with JDK 18

### DIFF
--- a/cars/v1/vanilla/config.ini
+++ b/cars/v1/vanilla/config.ini
@@ -16,7 +16,7 @@ jdk.unbundled.release_url = https://artifacts.elastic.co/downloads/elasticsearch
 
 docker_image=docker.elastic.co/elasticsearch/elasticsearch
 # major version of the JDK that is used to build Elasticsearch
-build.jdk = 18
+build.jdk = 17
 # list of JDK major versions that are used to run Elasticsearch
 runtime.jdk = 18,17,16,15,14,13,12,11
 runtime.jdk.bundled = true

--- a/cars/v1/vanilla/config.ini
+++ b/cars/v1/vanilla/config.ini
@@ -16,7 +16,7 @@ jdk.unbundled.release_url = https://artifacts.elastic.co/downloads/elasticsearch
 
 docker_image=docker.elastic.co/elasticsearch/elasticsearch
 # major version of the JDK that is used to build Elasticsearch
-build.jdk = 17
+build.jdk = 18
 # list of JDK major versions that are used to run Elasticsearch
-runtime.jdk = 17,16,15,14,13,12,11
+runtime.jdk = 18,17,16,15,14,13,12,11
 runtime.jdk.bundled = true


### PR DESCRIPTION
With this commit we set the required JDK for compiling Elasticsearch to
JDK 18 and also allow it to run with JDK 18.

Note that this won't affect our nightly benchmarks as they use the bundled JDK. But it will allow Rally to use Java 18 with default settings. To test this, tell Rally to use your rally-teams checkout:

```ini
[mechanic]
team.path = /path/to/rally-teams
```

I plan to backport this to the 6.3, 7, 7.11 and 7.17 branches since Rally only supports 6.8+ now.