### PR TITLE
Add arch specific build commands

### DIFF
--- a/cars/v1/vanilla/config.ini
+++ b/cars/v1/vanilla/config.ini
@@ -3,7 +3,7 @@ clean_command = ./gradlew clean
 # deprecated
 build_command = ./gradlew :distribution:archives:linux-tar:assemble
 # new
-system.build_command = ./gradlew :distribution:archives:{{OSNAME}}-tar:assemble
+system.build_command = ./gradlew :distribution:archives:{{OSNAME}}-{{ARCH}}-tar:assemble
 # deprecated
 artifact_path_pattern = distribution/archives/linux-tar/build/distributions/*.tar.gz
 # new

--- a/cars/v1/vanilla/config.ini
+++ b/cars/v1/vanilla/config.ini
@@ -3,11 +3,13 @@ clean_command = ./gradlew clean
 # deprecated
 build_command = ./gradlew :distribution:archives:linux-tar:assemble
 # new
-system.build_command = ./gradlew :distribution:archives:{{OSNAME}}-{{ARCH}}-tar:assemble
+system.build_command = ./gradlew :distribution:archives:{{OSNAME}}-tar:assemble
+system.build_command.arch = ./gradlew :distribution:archives:{{OSNAME}}-{{ARCH}}-tar:assemble
 # deprecated
 artifact_path_pattern = distribution/archives/linux-tar/build/distributions/*.tar.gz
 # new
 system.artifact_path_pattern = distribution/archives/{{OSNAME}}-tar/build/distributions/*.tar.gz
+system.artifact_path_pattern.arch = distribution/archives/{{OSNAME}}-{{ARCH}}-tar/build/distributions/*.tar.gz
 # deprecated
 release_url = https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{VERSION}}-linux-x86_64.tar.gz
 # new


### PR DESCRIPTION
With the introduction of a specific `build` subcommand in Rally we require arch specific build commands and artifact paths.

Relates https://github.com/elastic/rally/pull/1576