### PR TITLE
Remove plugins that have been converted to modules

### DIFF
--- a/plugins/v1/core-plugins.txt
+++ b/plugins/v1/core-plugins.txt
@@ -26,9 +26,6 @@ mapper-attachments
 mapper-murmur3
 mapper-size
 # 'repository-*' requires custom config
-repository-azure
-repository-gcs
 repository-hdfs
-repository-s3
 store-smb
 transport-nio


### PR DESCRIPTION
Note that we retain the respective plugin's directory and corresponding `plugin.py` file, because although these are no longer 'plugins', we are still relying on the post-install hooks to configure the Elasticsearch keystore. 

See See https://github.com/elastic/rally/issues/1622