### PR TITLE
Only set discovery seed hosts if greater than 1

### DIFF
--- a/cars/v1/vanilla/templates/config/elasticsearch.yml
+++ b/cars/v1/vanilla/templates/config/elasticsearch.yml
@@ -69,12 +69,27 @@ transport.port: {{transport_port}}
 # The default list of hosts is ["127.0.0.1", "[::1]"]
 #
 {%- if all_node_ips %}
+  {%- if all_node_ips_count is defined %}
+    {%- if all_node_ips_count > 1 %}
 discovery.seed_hosts: {{ all_node_ips }}
 # Prevent split brain by specifying the initial master nodes.
-  {%- if all_node_names is defined %}
+      {%- if all_node_names is defined %}
 cluster.initial_master_nodes: {{ all_node_names }}
-  {%- else %}
+      {%- else %}
 cluster.initial_master_nodes: {{ all_node_ips }}
+      {%- endif %}
+    {%- else %}
+#discovery.seed_hosts: ["host1", "host2"]
+#cluster.initial_master_nodes: ["node-name1", "node-name2"]
+    {%- endif %}
+  {%- else %}
+discovery.seed_hosts: {{ all_node_ips }}
+# Prevent split brain by specifying the initial master nodes.
+    {%- if all_node_names is defined %}
+cluster.initial_master_nodes: {{ all_node_names }}
+    {%- else %}
+cluster.initial_master_nodes: {{ all_node_ips }}
+    {%- endif %}
   {%- endif %}
 {%- else %}
 #discovery.seed_hosts: ["host1", "host2"]


### PR DESCRIPTION
Consumes a variable for the discovery seed node count, if set by the provisioner, to prevent configuring discovery for single-node clusters. The implementation is backward compatible with previous Rally versions in that it reverts to the old behavior if the variable is unset. This is one of two PRs to address https://github.com/elastic/rally/issues/1644.