### PR TITLE
Revert "Only set discovery seed hosts if greater than 1"

### DIFF
--- a/cars/v1/vanilla/templates/config/elasticsearch.yml
+++ b/cars/v1/vanilla/templates/config/elasticsearch.yml
@@ -68,15 +68,13 @@ transport.port: {{transport_port}}
 # Pass an initial list of hosts to perform discovery when this node is started:
 # The default list of hosts is ["127.0.0.1", "[::1]"]
 #
-{%- if all_node_ips|length > 4 %}
-  {%- if all_node_ips_count|default(2) > 1 %}
+{%- if all_node_ips %}
 discovery.seed_hosts: {{ all_node_ips }}
 # Prevent split brain by specifying the initial master nodes.
-    {%- if all_node_names is defined %}
+  {%- if all_node_names is defined %}
 cluster.initial_master_nodes: {{ all_node_names }}
-      {%- else %}
+  {%- else %}
 cluster.initial_master_nodes: {{ all_node_ips }}
-      {%- endif %}
   {%- endif %}
 {%- else %}
 #discovery.seed_hosts: ["host1", "host2"]


### PR DESCRIPTION
Reverts elastic/rally-teams#77

As soon as this was merged, this broke our nightly benchmarks with the following error message:

> [2023-01-18T11:56:56,877][INFO ][o.e.t.TransportService   ] [rally-node-0] publish_address {192.168.20.29:9300}, bound_addresses {192.168.20.29:9300}
[2023-01-18T11:56:56,985][INFO ][o.e.b.BootstrapChecks    ] [rally-node-0] bound or publishing to a non-loopback address, enforcing bootstrap checks
bootstrap check failure [1] of [1]: the default discovery settings are unsuitable for production use; at least one of [discovery.seed_hosts, discovery.seed_providers, cluster.initial_master_nodes] must be configured

Indeed, the way Elasticsearch differentiates development vs. production mode is the address that Elasticsearch is bound to, not the number of nodes in the cluster: https://www.elastic.co/guide/en/elasticsearch/reference/8.6/bootstrap-checks.html#dev-vs-prod-mode

cc @inqueue @danielmitterdorfer for awareness