### PR TITLE
Include Panama Vector module in 'jvm.options'

### DIFF
--- a/cars/v1/vanilla/templates/config/jvm.options
+++ b/cars/v1/vanilla/templates/config/jvm.options
@@ -60,6 +60,10 @@
 ## JVM temporary directory
 -Djava.io.tmpdir=${ES_TMPDIR}
 
+# Leverages accelerated vector hardware instructions; removing this may
+# result in less optimal vector performance
+20:--add-modules=jdk.incubator.vector
+
 ## heap dumps
 
 # generate a heap dump when an allocation from the Java heap fails


### PR DESCRIPTION
as per https://github.com/elastic/elasticsearch/pull/96453 this now a default setting in `jvm.options`.