### PR TITLE
Add mixin with lean watermark levels

### DIFF
--- a/cars/v1/lean-watermarks.ini
+++ b/cars/v1/lean-watermarks.ini
@@ -1,0 +1,11 @@
+[meta]
+description=Configure lean watermark levels (useful in testing with little disk resources)
+type=mixin
+
+[config]
+base=lean_watermarks
+
+[variables]
+#watermark_low=500mb
+#watermark_high=300mb
+#watermark_flood_stage=100mb

--- a/cars/v1/lean-watermarks.ini
+++ b/cars/v1/lean-watermarks.ini
@@ -6,6 +6,6 @@ type=mixin
 base=lean_watermarks
 
 [variables]
-#watermark_low=500mb
-#watermark_high=300mb
-#watermark_flood_stage=100mb
+watermark_low=500mb
+watermark_high=300mb
+watermark_flood_stage=100mb

--- a/cars/v1/lean_watermarks/templates/config/elasticsearch.yml
+++ b/cars/v1/lean_watermarks/templates/config/elasticsearch.yml
@@ -1,3 +1,3 @@
-cluster.routing.allocation.disk.watermark.low: {{watermark_low|default("500mb")}}
-cluster.routing.allocation.disk.watermark.high: {{watermark_high|default("300mb")}}
-cluster.routing.allocation.disk.watermark.flood_stage: {{watermark_flood_stage|default("100mb")}}
+cluster.routing.allocation.disk.watermark.low: {{watermark_low}}
+cluster.routing.allocation.disk.watermark.high: {{watermark_high}}
+cluster.routing.allocation.disk.watermark.flood_stage: {{watermark_flood_stage}}

--- a/cars/v1/lean_watermarks/templates/config/elasticsearch.yml
+++ b/cars/v1/lean_watermarks/templates/config/elasticsearch.yml
@@ -1,0 +1,3 @@
+cluster.routing.allocation.disk.watermark.low: {{watermark_low|default("500mb")}}
+cluster.routing.allocation.disk.watermark.high: {{watermark_high|default("300mb")}}
+cluster.routing.allocation.disk.watermark.flood_stage: {{watermark_flood_stage|default("100mb")}}


### PR DESCRIPTION
Mixin with watermark levels suitable for environments with small disks.

Testing:
1. Install ES and note installation ID.
```
esrally install --team-path=../rally-teams --car="4gheap,lean-watermarks" --distribution-version=8.9.0 --http-port=9200 --node=rally-node-0 --master-nodes=rally-node-0 --seed-hosts="127.0.0.1:9300"
```
2. Verify `elasticsearch.yml` includes the following.
```
cluster.routing.allocation.disk.watermark.low: 500mb
cluster.routing.allocation.disk.watermark.high: 300mb
cluster.routing.allocation.disk.watermark.flood_stage: 100mb
```
3. Start ES.
```
esraly start --installation-id=<installation-id-from-step-1> --race-id=dummy-race-id
```
4. Verify ES started successfully and watermark levels were updated.
```
curl "localhost:9200/_cluster/settings?flat_settings&include_defaults&pretty" -s | grep watermark
```
5. Stop ES.
```
esrally stop --installation-id=<installation-id-from-step-1>
```