### PR TITLE
Update version range for Panama Vector module in 'jvm.options'

### DIFF
--- a/cars/v1/vanilla/templates/config/jvm.options
+++ b/cars/v1/vanilla/templates/config/jvm.options
@@ -62,7 +62,7 @@
 
 # Leverages accelerated vector hardware instructions; removing this may
 # result in less optimal vector performance
-20:--add-modules=jdk.incubator.vector
+20-:--add-modules=jdk.incubator.vector
 
 ## heap dumps
 


### PR DESCRIPTION
This commit updates the version range for Panama Vector module in 'jvm.options'. The range is updated from just a single value 20, to a range starting from 20 with no upper bound. This effectively enables the Panama Vector API for use in Lucene on all JDK versions greater than 19.

When the vector module was originally added, it was just added for the currently shipping JDK release, JDK 20, see #79. Which is similar to what we did in Elasticsearch. We now updated Elasticsearch to include the vector module, for all JDK releases greater than 19, in a similar way to this PR, see https://github.com/elastic/elasticsearch/pull/99846.
