### PR TITLE
feat: add `x-pack-apm` mixin

### DIFF
--- a/cars/v1/x-pack-apm.ini
+++ b/cars/v1/x-pack-apm.ini
@@ -1,0 +1,9 @@
+[meta]
+description = X-Pack APM Data plugin
+type = mixin
+
+[config]
+base = vanilla,x_pack/base,x_pack/apm
+
+[variables]
+xpack_apmdata_enabled = true

--- a/cars/v1/x_pack/README.md
+++ b/cars/v1/x_pack/README.md
@@ -3,12 +3,14 @@ This directory contains example configurations for x-pack:
 * `x-pack-security`: Configures TLS for all HTTP and transport communication using self-signed certificates.
 * `x-pack-monitoring`: Enables x-pack monitoring.
 * `x-pack-ml`: Enables x-pack Machine Learning.
+* `x-pack-apm`: Enables x-pack apm-data plugin.
 
 The configurations have been implemented so that you can either only one of them or both together, i.e. all of the following combinations will work:
 
 * `--car="defaults,x-pack-security"`
 * `--car="defaults,x-pack-monitoring"`
 * `--car="defaults,x-pack-security,x-pack-monitoring-local"`
+* `--car="1gheap,x-pack-apm"`
 
 ## Parameters
 
@@ -67,3 +69,7 @@ The focus here is on providing a usable configuration for benchmarks. This confi
 * If you don't specify the car-params `x-pack_security_user_password` and `xpack_security_user_role`, Rally will add a "rally" user with super-user privileges with a hard-coded password.
 
 Both of these measures mean that the cluster is not any more secure than without using x-pack. But once again: The idea is to be able to measure the performance characteristics not to secure the cluster that is benchmarked.
+
+### x-pack-apm
+
+It installs index templates and ingest pipelines needed for APM Server. Note that it only works with Elasticsearch version 8.12 or later. If you observe the Node start failure when starting a race, make sure you specified the car.(not `--car="x-pack-apm"` but `--car="default,x-pack-apm` or `--car="1gheap,x-pack-apm`)

--- a/cars/v1/x_pack/apm/templates/config/elasticsearch.yml
+++ b/cars/v1/x_pack/apm/templates/config/elasticsearch.yml
@@ -1,0 +1,1 @@
+xpack.apm_data.enabled: true


### PR DESCRIPTION
relates to https://github.com/elastic/rally-tracks/pull/550

Add mixin to enable `xpack.apm_data` plugin

cc @elastic/apm-server 