### PR TITLE
Add JDK 22 to list of runtime JDKs

### DIFF
--- a/cars/v1/vanilla/config.ini
+++ b/cars/v1/vanilla/config.ini
@@ -20,5 +20,5 @@ docker_image=docker.elastic.co/elasticsearch/elasticsearch
 # major version of the JDK that is used to build Elasticsearch
 build.jdk = 17
 # list of JDK major versions that are used to run Elasticsearch
-runtime.jdk = 21,20,19,18,17,16,15,14,13,12,11
+runtime.jdk = 22,21,20,19,18,17,16,15,14,13,12,11
 runtime.jdk.bundled = true


### PR DESCRIPTION
I spotted we are missing JDK22 from the list of JDKs