### PR TITLE
Bump to JDK21 for build

### DIFF
--- a/cars/v1/vanilla/config.ini
+++ b/cars/v1/vanilla/config.ini
@@ -18,7 +18,7 @@ jdk.unbundled.release_url = https://artifacts.elastic.co/downloads/elasticsearch
 
 docker_image=docker.elastic.co/elasticsearch/elasticsearch
 # major version of the JDK that is used to build Elasticsearch
-build.jdk = 17
+build.jdk = 21
 # list of JDK major versions that are used to run Elasticsearch
-runtime.jdk = 22,21,20,19,18,17,16,15,14,13,12,11
+runtime.jdk = 23,22,21,20,19,18,17,16,15,14,13,12,11
 runtime.jdk.bundled = true


### PR DESCRIPTION
Due to https://github.com/elastic/elasticsearch/pull/112252 we now need a minimum of JDK21 to build Elasticsearch from main. This bumps the build version, for comparisons to older versions, we will need to use a revision of rally-teams rather than master