### PR TITLE
Cleanup Lucene snapshot JAR files

### DIFF
--- a/cars/v1/vanilla/config.ini
+++ b/cars/v1/vanilla/config.ini
@@ -1,5 +1,5 @@
 [variables]
-clean_command = ./gradlew --no-daemon clean
+clean_command = find ~/.gradle/caches -name 'lucene-*-snapshot-*.jar' -delete; ./gradlew --no-daemon clean
 # deprecated
 build_command = ./gradlew :distribution:archives:linux-tar:assemble
 # new

--- a/cars/v1/vanilla/config.ini
+++ b/cars/v1/vanilla/config.ini
@@ -1,4 +1,7 @@
 [variables]
+# Gradle clean is preceded with removal of Lucene snapshot JAR files which
+# may change content/hash but not the filename which can fail the build. This
+# might be removed once Lucene produces archives in a reproducible way.
 clean_command = find ~/.gradle/caches -name 'lucene-*-snapshot-*.jar' -delete; ./gradlew --no-daemon clean
 # deprecated
 build_command = ./gradlew :distribution:archives:linux-tar:assemble


### PR DESCRIPTION
Recent switch from `main` to `lucene_snapshot` for nightly builds surfaced a problem with Lucene snapshot JAR files. They might change content and therefore hash but not the filename. In environments where Gradle cache is kept between the builds this can fail the build because Gradle verification metadata in ES is automatically synced with Lucene, while Gradle does not re-download the file if it's already present.

As a workaround, this change precedes Gradle clean command with surgical removal of Lucene snapshot JAR files from the Gradle cache.