### PR TITLE
Apply MADV_NORMAL for Lucene 10 testing

### DIFF
--- a/cars/v1/vanilla/templates/config/jvm.options
+++ b/cars/v1/vanilla/templates/config/jvm.options
@@ -64,6 +64,9 @@
 # result in less optimal vector performance
 20-:--add-modules=jdk.incubator.vector
 
+# Lucene 10 testing: apply MADV_NORMAL advice to enable more aggressive readahead
+-Dorg.apache.lucene.store.defaultReadAdvice=normal
+
 ## heap dumps
 
 # generate a heap dump when an allocation from the Java heap fails


### PR DESCRIPTION
Nightly benchmarks with Lucene 10 suggest MADV_RANDOM advice might be causing warmup regressions. We want to verify if switching back to MADV_NORMAL will help, and what the overall impact will be across all the nightly tests.