### PR TITLE
Add JIT compiler directives to workaround performance regression in memory segment access in JDK 23

### DIFF
--- a/cars/v1/vanilla/templates/config/jvm.options
+++ b/cars/v1/vanilla/templates/config/jvm.options
@@ -64,6 +64,10 @@
 # result in less optimal vector performance
 20-:--add-modules=jdk.incubator.vector
 
+# Required to workaround performance issue in JDK 23, https://github.com/elastic/elasticsearch/issues/113030
+23:-XX:CompileCommand=dontinline,java/lang/invoke/MethodHandle.setAsTypeCache
+23:-XX:CompileCommand=dontinline,java/lang/invoke/MethodHandle.asTypeUncached
+
 # Lucene 10 testing: apply MADV_NORMAL advice to enable more aggressive readahead
 -Dorg.apache.lucene.store.defaultReadAdvice=normal
 


### PR DESCRIPTION
Port of https://github.com/elastic/elasticsearch/pull/113817.