### PR TITLE
Only set discovery seed hosts if greater than 1 (revisited)

### DIFF
--- a/cars/v1/vanilla/templates/config/elasticsearch.yml
+++ b/cars/v1/vanilla/templates/config/elasticsearch.yml
@@ -77,6 +77,8 @@ cluster.initial_master_nodes: {{ all_node_names }}
       {%- else %}
 cluster.initial_master_nodes: {{ all_node_ips }}
       {%- endif %}
+  {%- else %}
+discovery.type: single-node
   {%- endif %}
 {%- else %}
 #discovery.seed_hosts: ["host1", "host2"]

--- a/cars/v1/vanilla/templates/config/elasticsearch.yml
+++ b/cars/v1/vanilla/templates/config/elasticsearch.yml
@@ -68,13 +68,15 @@ transport.port: {{transport_port}}
 # Pass an initial list of hosts to perform discovery when this node is started:
 # The default list of hosts is ["127.0.0.1", "[::1]"]
 #
-{%- if all_node_ips %}
+{%- if all_node_ips|length > 4 %}
+  {%- if all_node_ips_count|default(2) > 1 %}
 discovery.seed_hosts: {{ all_node_ips }}
 # Prevent split brain by specifying the initial master nodes.
-  {%- if all_node_names is defined %}
+    {%- if all_node_names is defined %}
 cluster.initial_master_nodes: {{ all_node_names }}
-  {%- else %}
+      {%- else %}
 cluster.initial_master_nodes: {{ all_node_ips }}
+      {%- endif %}
   {%- endif %}
 {%- else %}
 #discovery.seed_hosts: ["host1", "host2"]


### PR DESCRIPTION
I'm revisiting https://github.com/elastic/rally-teams/pull/77. The Rally PR is in https://github.com/elastic/rally/pull/1953.