### PR TITLE
[9.0] Only set discovery seed hosts if greater than 1 (revisited) (#92)

### DIFF
--- a/cars/v1/vanilla/templates/config/elasticsearch.yml
+++ b/cars/v1/vanilla/templates/config/elasticsearch.yml
@@ -68,13 +68,17 @@ transport.port: {{transport_port}}
 # Pass an initial list of hosts to perform discovery when this node is started:
 # The default list of hosts is ["127.0.0.1", "[::1]"]
 #
-{%- if all_node_ips %}
+{%- if all_node_ips|length > 4 %}
+  {%- if all_node_ips_count|default(2) > 1 %}
 discovery.seed_hosts: {{ all_node_ips }}
 # Prevent split brain by specifying the initial master nodes.
-  {%- if all_node_names is defined %}
+    {%- if all_node_names is defined %}
 cluster.initial_master_nodes: {{ all_node_names }}
-  {%- else %}
+      {%- else %}
 cluster.initial_master_nodes: {{ all_node_ips }}
+      {%- endif %}
+  {%- else %}
+discovery.type: single-node
   {%- endif %}
 {%- else %}
 #discovery.seed_hosts: ["host1", "host2"]


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `9.0`:
 - [Only set discovery seed hosts if greater than 1 (revisited) (#92)](https://github.com/elastic/rally-teams/pull/92)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Grzegorz Banasiak","email":"grzegorz.banasiak@elastic.co"},"sourceCommit":{"committedDate":"2025-06-23T05:36:13Z","message":"Only set discovery seed hosts if greater than 1 (revisited) (#92)\n\nUse \"discovery.type: single-node\" instead of \"discovery.seed_hosts\" with\nsingle-node clusters.","sha":"b6855b36ffe4ecfa19e9f4a1550b6e1d6bfdce95"},"sourcePullRequest":{"labels":["bug","backport pending","v8.19","v9.0"],"title":"Only set discovery seed hosts if greater than 1 (revisited)","number":92,"url":"https://github.com/elastic/rally-teams/pull/92","mergeCommit":{"message":"Only set discovery seed hosts if greater than 1 (revisited) (#92)\n\nUse \"discovery.type: single-node\" instead of \"discovery.seed_hosts\" with\nsingle-node clusters.","sha":"b6855b36ffe4ecfa19e9f4a1550b6e1d6bfdce95"}},"sourceBranch":"master","suggestedTargetBranches":["8.19","9.0"],"targetPullRequestStates":[{"branch":"8.19","label":"v8.19","branchLabelMappingKey":"^v(\\d{1,2}).(\\d{1,2})$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0","branchLabelMappingKey":"^v(\\d{1,2}).(\\d{1,2})$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->