### PR TITLE
Update docs and branchLabelMapping after label creation of next minor (v9.4)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -2,6 +2,7 @@
   "repoOwner": "elastic",
   "repoName": "rally-teams",
   "targetBranchChoices": [
+    "9.3",
     "9.2",
     "9.1",
     "9.0",
@@ -11,6 +12,7 @@
     "backport"
   ],
   "branchLabelMapping": {
+    "^v9.4$" : "master",
     "^v(\\d{1,2}).(\\d{1,2})$" : "$1.$2"
   },
   "autoMerge": true,

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Contributions of new cars should be compatible with the `main` version of Elasti
 Backporting ensures compatibility of cars with both the latest main version of Elasticsearch and older versions. Periodic reminders will be issued when a backport is pending as part of the contribution process.
 
 To initiate backporting of a pull request, at least one `vX.Y` label must be applied.
-- Apply all labels corresponding to the current and previous Elasticsearch versions with which the pull request is expected to be compatible, selecting only from the available options.
-- If the pull request introduces functionality dependent on future Elasticsearch versions, please wait until the relevant `X.Y` version branch is created. In such cases, it is recommended to retain the `'backport pending'` label on the pull request to enable periodic notifications regarding the pending backport.
+- Please supply all the labels that correspond to next, current and past elasticsearch versions you expect this PR to work with, but choose only from all the available ones.
+- If the PR being merged is using functionality from future Elasticsearch versions, please wait for the creation of Elasticsearch `vX.Y` version branch.
 
 When a `vX.Y` label is added, a new pull request is automatically created, unless merge conflicts are detected. The status of this process is reported via a comment, and if successful, a link to the newly opened pull request targeting the specified version branch is provided. This pull request will include a backport label and will require a review. Upon approval, it will be merged automatically.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To initiate backporting of a pull request, at least one `vX.Y` label must be app
 - Please supply all the labels that correspond to next, current and past elasticsearch versions expected to work with this PR, but select only from the available ones.
 - If the PR being merged is using functionality from future Elasticsearch versions, please wait for the creation of Elasticsearch `vX.Y` version branch.
 
-When a `vX.Y` label is added, a new pull request is automatically created, unless merge conflicts are detected. The status of this process is reported via a comment, and if successful, a link to the newly opened pull request targeting the specified version branch is provided. This pull request will include a backport label and will require a review. Upon approval, it will be merged automatically.
+When a `vX.Y` label is added, a new pull request is automatically created, unless merge conflicts are detected or if the label supplied points to the next Elasticsearch minor version. The status of this process is reported via a comment, and if successful, a link to the newly opened pull request targeting the specified version branch is provided. This pull request will include a backport label and will require a review. Upon approval, it will be merged automatically.
 
 ## Merge conflicts
 Merge conflicts must be resolved manually. There are two primary methods for manually creating a backport pull request:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Contributions of new cars should be compatible with the `main` version of Elasti
 Backporting ensures compatibility of cars with both the latest main version of Elasticsearch and older versions. Periodic reminders will be issued when a backport is pending as part of the contribution process.
 
 To initiate backporting of a pull request, at least one `vX.Y` label must be applied.
-- Please supply all the labels that correspond to next, current and past elasticsearch versions you expect this PR to work with, but choose only from all the available ones.
+- Please supply all the labels that correspond to next, current and past elasticsearch versions expected to work with this PR, but select only from the available ones.
 - If the PR being merged is using functionality from future Elasticsearch versions, please wait for the creation of Elasticsearch `vX.Y` version branch.
 
 When a `vX.Y` label is added, a new pull request is automatically created, unless merge conflicts are detected. The status of this process is reported via a comment, and if successful, a link to the newly opened pull request targeting the specified version branch is provided. This pull request will include a backport label and will require a review. Upon approval, it will be merged automatically.
@@ -56,7 +56,7 @@ To complete the process, ensure the following:
 - Each associated backport pull request is labeled with backport.
 - Each backport pull request is merged into the appropriate version branch.
 
-Finally, remove the `backport pending` label from your PR.
+Finally, remove the `backport pending` label.
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ Contributions of new cars should be compatible with the `main` version of Elasti
 Backporting ensures compatibility of cars with both the latest main version of Elasticsearch and older versions. Periodic reminders will be issued when a backport is pending as part of the contribution process.
 
 To initiate backporting of a pull request, at least one `vX.Y` label must be applied.
-- Please supply all the labels that correspond to next, current and past elasticsearch versions expected to work with this PR, but select only from the available ones.
-- If the PR being merged is using functionality from future Elasticsearch versions, please wait for the creation of Elasticsearch `vX.Y` version branch.
+- Apply all the labels that correspond to Elasticsearch minor versions expected to work with this PR, but select only from the available ones.
 
 When a `vX.Y` label is added, a new pull request is automatically created, unless merge conflicts are detected or if the label supplied points to the next Elasticsearch minor version. The status of this process is reported via a comment, and if successful, a link to the newly opened pull request targeting the specified version branch is provided. This pull request will include a backport label and will require a review. Upon approval, it will be merged automatically.
 


### PR DESCRIPTION
We have decided that upon new Elasticsearch version, we ensure that labels for both current and next minors exist, ie if `9.3` gets out, both `9.3` and `9.4` gets created.
This should be also depicted in the documentation. 