### PR TITLE
Remove node certs before creating new ones

### DIFF
--- a/cars/v1/x_pack/base/config.py
+++ b/cars/v1/x_pack/base/config.py
@@ -57,6 +57,12 @@ def install_certificates(config_names, variables, **kwargs):
     certutil = resolve_binary(install_root, cert_binary)
     cert_bundle = os.path.join(install_root, "node-cert.zip")
 
+    # Remove stale cert bundle from a previous (preserved) installation to
+    # avoid elasticsearch-certutil exiting with "output file exists".
+    if os.path.exists(cert_bundle):
+        logger.info("Removing stale certificate bundle [%s].", cert_bundle)
+        os.remove(cert_bundle)
+
     return_code = process.run_subprocess_with_logging(
         '{certutil} cert --silent --in "{instances_yml}" --out="{cert_bundle}" --ca-cert="{ca_path}/ca.crt" '
         '--ca-key="{ca_path}/ca.key" --pass ""'.format(


### PR DESCRIPTION
During ES installation (`esrally install`) `elasticsearch-certutil` writes to `{install_root}/node-cert.zip`. If the installation path is preserved using `preserve_elasticsearch_install=True` a second `esrally install` with car overrides results in "exit code 74: output file already exists" 

That is because 
1. At the 2nd pass rally extracts the ES tarball with the [ElasticsearchInstaller.install()](https://github.com/NickDris/rally/blob/master/esrally/mechanic/provisioner.py#L280-L284) but `install_dir` already exists with the old `node-cert.zip` from 1st benchmark.
2. [`delete_pre_bundled_configuration()`](https://github.com/NickDris/rally/blob/master/esrally/mechanic/provisioner.py#L291-L295) only deletes the `config/` subdirectory.
3. A 2nd execution of [`elasticsearch-certutil cert --out="{install_root}/node-cert.zip"`](https://github.com/elastic/rally-teams/blob/8/cars/v1/x_pack/base/config.py#L60-L71) after the [post installation hook](https://github.com/NickDris/rally/blob/master/esrally/mechanic/team.py#L501) results to file already exists → exit code 74.

This was revealed when trying to execute sequential benchmark experiments with ES reinstallation using different cluster settings per experiment and preserve the elasticsearch directory during the benchmark executions.
Before that, I was running all experiments using identical install parameters, so the preserved installation was functionally fine.

This aims to clean the certs directory before extracting.